### PR TITLE
Correctly parse float/double even with nordic locale

### DIFF
--- a/JavaToCSharp/Expressions/DoubleLiteralExpressionVisitor.cs
+++ b/JavaToCSharp/Expressions/DoubleLiteralExpressionVisitor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using com.github.javaparser.ast.expr;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -7,6 +8,13 @@ namespace JavaToCSharp.Expressions
 {
     public class DoubleLiteralExpressionVisitor : ExpressionVisitor<DoubleLiteralExpr>
     {
+        CultureInfo ci;
+        public DoubleLiteralExpressionVisitor()
+        {
+            ci = (CultureInfo)CultureInfo.CurrentCulture.Clone();
+            ci.NumberFormat.CurrencyDecimalSeparator = ".";
+        }
+
         public override ExpressionSyntax Visit(ConversionContext context, DoubleLiteralExpr expr)
         {
             // note: this must come before the check for StringLiteralExpr because DoubleLiteralExpr : StringLiteralExpr
@@ -14,9 +22,9 @@ namespace JavaToCSharp.Expressions
 
             var value = dbl.getValue().Replace("_", string.Empty);
             if (value.EndsWith("f", StringComparison.OrdinalIgnoreCase))
-                return SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(float.Parse(value.TrimEnd('f', 'F'))));
+                return SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(float.Parse(value.TrimEnd('f', 'F'), NumberStyles.Any, ci)));
             else
-                return SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(double.Parse(value.TrimEnd('d', 'D'))));
+                return SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(double.Parse(value.TrimEnd('d', 'D'), NumberStyles.Any, ci)));
         }
     }
 }


### PR DESCRIPTION
Nordic locale wants to use float/double numbers in format "0,00" by default. Which of course does not work very well with the java/c# syntax. Force the default locale to always use dot instead.