### PR TITLE
Add xUnit test project and ConvertTypeTests

### DIFF
--- a/JavaToCSharp.Tests/ConvertTypeTests.cs
+++ b/JavaToCSharp.Tests/ConvertTypeTests.cs
@@ -1,0 +1,32 @@
+using JavaToCSharp;
+using Xunit;
+
+namespace TypeHelperTests
+{
+    public class ConvertTypeTests
+    {
+        [Fact]
+        public void ConvertType_Int()
+        {
+            string typeName = "int";
+            string type = TypeHelper.ConvertType(typeName);
+            Assert.Equal("int", type);
+        }
+
+        [Fact]
+        public void ConvertType_String()
+        {
+            string typeName = "string";
+            string type = TypeHelper.ConvertType(typeName);
+            Assert.Equal("string", type);
+        }
+
+        [Fact]
+        public void ConvertType_IntArray_BracketsAfterType()
+        {
+            string typeName = "int[]";
+            string type = TypeHelper.ConvertType(typeName);
+            Assert.Equal("int[]", type);
+        }
+    }
+}

--- a/JavaToCSharp.Tests/JavaToCSharp.Tests.csproj
+++ b/JavaToCSharp.Tests/JavaToCSharp.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\JavaToCSharp\JavaToCSharp.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="javaparser-core-3.0.0-SNAPSHOT">
+      <HintPath>..\Lib\javaparser-core-3.0.0-SNAPSHOT.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/JavaToCSharp.sln
+++ b/JavaToCSharp.sln
@@ -20,6 +20,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JavaToCSharp.Tests", "JavaToCSharp.Tests\JavaToCSharp.Tests.csproj", "{0CBBEF05-FD79-474A-A5F0-25B341B8B77D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{DE56E074-10C7-47BA-8E8A-DAB0F3F92181}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -38,9 +42,16 @@ Global
 		{DAA3F412-0460-40C3-98F7-3244649820F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DAA3F412-0460-40C3-98F7-3244649820F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DAA3F412-0460-40C3-98F7-3244649820F9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0CBBEF05-FD79-474A-A5F0-25B341B8B77D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0CBBEF05-FD79-474A-A5F0-25B341B8B77D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0CBBEF05-FD79-474A-A5F0-25B341B8B77D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0CBBEF05-FD79-474A-A5F0-25B341B8B77D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{0CBBEF05-FD79-474A-A5F0-25B341B8B77D} = {DE56E074-10C7-47BA-8E8A-DAB0F3F92181}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {EB538484-5025-4753-B0A5-2C66A6C06193}


### PR DESCRIPTION
Fixes #13 

## Proposed changes

- Added a _Tests_ solution folder and a xUnit test project named _JavaToCSharp.Tests_
- Added `ConvertTypeTests` with 1 failing test [`ConvertType_IntArray_BracketsAfterType()`](https://github.com/paulirwin/JavaToCSharp/pull/14/files#diff-9d93d02796cb5de8c744619a3ea65d4d31afa16ac33c368c1bc3ede25b29423dR25) to demonstrate the issue in #11. I plan to submit separate PR for that issue which will also fix the failing test.

## Customer Impact

- Improves the development experience by having tests

## Regression?

- No

## Risk

- Minimal

## Test Methodology

- Ran the newly added tests in the Test Explorer
- Ran the newly added tests using `dotnet test` from the command line
