### PR TITLE
Preserve array square bracket pairs when parsing type names

### DIFF
--- a/JavaToCSharp.Tests/ConvertTypeTests.cs
+++ b/JavaToCSharp.Tests/ConvertTypeTests.cs
@@ -8,25 +8,19 @@ namespace TypeHelperTests
         [Fact]
         public void ConvertType_Int()
         {
-            string typeName = "int";
-            string type = TypeHelper.ConvertType(typeName);
-            Assert.Equal("int", type);
+            Assert.Equal("int", TypeHelper.ConvertType("int"));
         }
 
         [Fact]
         public void ConvertType_String()
         {
-            string typeName = "string";
-            string type = TypeHelper.ConvertType(typeName);
-            Assert.Equal("string", type);
+            Assert.Equal("string", TypeHelper.ConvertType("string"));
         }
 
         [Fact]
         public void ConvertType_IntArray_BracketsAfterType()
         {
-            string typeName = "int[]";
-            string type = TypeHelper.ConvertType(typeName);
-            Assert.Equal("int[]", type);
+            Assert.Equal("int[]", TypeHelper.ConvertType("int[]"));
         }
     }
 }

--- a/JavaToCSharp/TypeNameParser.cs
+++ b/JavaToCSharp/TypeNameParser.cs
@@ -12,13 +12,15 @@ namespace JavaToCSharp
             Identifier,
             Extends,
             Super,
-            LeftBracket,
-            RightBracket,
+            LeftSquareBracket,
+            RightSquareBracket,
+            LeftAngleBracket,
+            RightAngleBracket,
             Comma,
             QuestionMark
         }
 
-        private static readonly Regex _tokenizePattern = new(@"\w+|<|>|,|\?", RegexOptions.Compiled);
+        private static readonly Regex _tokenizePattern = new(@"\w+|\[|\]|<|>|,|\?", RegexOptions.Compiled);
 
         private static (string, TokenType)[] _tokens;
         private static (string text, TokenType type) _token;
@@ -41,7 +43,7 @@ namespace JavaToCSharp
             _sb.Clear();
 
             if (TypeName() && _token.type is TokenType.EndOfString)
-            { 
+            {
                 // Otherwise we have extra tokens.
                 return _sb.ToString();
             }
@@ -59,8 +61,10 @@ namespace JavaToCSharp
                 string s = match.Value;
                 tokens[i] = s switch
                 {
-                    "<" => (s, TokenType.LeftBracket),
-                    ">" => (s, TokenType.RightBracket),
+                    "[" => (s, TokenType.LeftSquareBracket),
+                    "]" => (s, TokenType.RightSquareBracket),
+                    "<" => (s, TokenType.LeftAngleBracket),
+                    ">" => (s, TokenType.RightAngleBracket),
                     "," => (s, TokenType.Comma),
                     "?" => (s, TokenType.QuestionMark),
                     "extends" => (s, TokenType.Extends),
@@ -84,7 +88,7 @@ namespace JavaToCSharp
             {
                 _sb.Append(_translate(_token.text));
                 NextToken();
-                if (_token.type is TokenType.LeftBracket)
+                if (_token.type is TokenType.LeftAngleBracket)
                 {
                     _sb.Append("<");
                     NextToken();
@@ -96,7 +100,7 @@ namespace JavaToCSharp
                             NextToken();
                             if (!TypeArgument()) return false;
                         }
-                        if (_token.type is TokenType.RightBracket)
+                        if (_token.type is TokenType.RightAngleBracket)
                         {
                             _sb.Append(">");
                             NextToken();


### PR DESCRIPTION
Fixes #11 

## Proposed changes

- Fix the type name parser tokenize pattern to also match on left and right square brackets so that array square bracket pairs may be preserved during conversion.

## Customer Impact

- Array square bracket pairs will now be preserved during conversion.

## Regression?

- No

## Risk

- Could break people who expect the array square brackets to get dropped but this is unlikely and not something that should be considered breaking.

## Test Methodology

- Ran unit tests and the previously failing test `ConvertType_IntArray_BracketsAfterType()` is now passing.
