### PR TITLE
fix `loop nested calls` to `VisitExpression` in `TypeHelper.TryTransformMethodCall`

### DIFF
--- a/JavaToCSharp/TypeHelper.cs
+++ b/JavaToCSharp/TypeHelper.cs
@@ -178,20 +178,24 @@ namespace JavaToCSharp
         {
             if (methodCallExpr.getScope() is ast.expr.Expression scope)
             {
-                string methodName = methodCallExpr.getName();
+                var methodName = methodCallExpr.getName();
                 var args = methodCallExpr.getArgs();
-                ExpressionSyntax scopeSyntax = ExpressionVisitor.VisitExpression(context, scope);
 
                 switch (methodName)
                 {
                     case "size" when args.size() == 0:
-                        transformedSyntax = ReplaceSizeByCount(scopeSyntax);
+                        var scopeSyntaxSize = ExpressionVisitor.VisitExpression(context, scope);
+                        transformedSyntax = ReplaceSizeByCount(scopeSyntaxSize);
                         return true;
+
                     case "get" when args.size() == 1:
-                        transformedSyntax = ReplaceGetByIndexAccess(context, scopeSyntax, args);
+                        var scopeSyntaxGet = ExpressionVisitor.VisitExpression(context, scope);
+                        transformedSyntax = ReplaceGetByIndexAccess(context, scopeSyntaxGet, args);
                         return true;
+
                     case "set" when args.size() == 2:
-                        transformedSyntax = ReplaceSetByIndexAccess(context, scopeSyntax, args);
+                        var scopeSyntaxSet = ExpressionVisitor.VisitExpression(context, scope);
+                        transformedSyntax = ReplaceSetByIndexAccess(context, scopeSyntaxSet, args);
                         return true;
                 }
             }


### PR DESCRIPTION
- fix useless calls to `ExpressionVisitor.VisitExpression()` in `TypeHelper.TryTransformMethodCall` implementations.
- Long `Fluent method` calls trigger `loop nested calls`

## Sample:
```java
package com.ruoyi.framework.config;

public class SecurityConfig
{
    @Override
    protected void configure(HttpSecurity httpSecurity) throws Exception
    {
        httpSecurity
                .csrf().disable()
                .exceptionHandling().authenticationEntryPoint(unauthorizedHandler).and()
                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
                .authorizeRequests()
                .antMatchers("/login", "/register", "/captchaImage").anonymous()
                .antMatchers(
                        HttpMethod.GET,
                        "/",
                        "/*.html",
                        "/**/*.html",
                        "/**/*.css",
                        "/**/*.js",
                        "/profile/**"
                ).permitAll()
                .antMatchers("/swagger-ui.html").anonymous()
                .antMatchers("/swagger-resources/**").anonymous()
                .antMatchers("/webjars/**").anonymous()
                .antMatchers("/*/api-docs").anonymous()
                .antMatchers("/druid/**").anonymous()
                .anyRequest().authenticated()
                .and()
                .headers().frameOptions().disable();
    }
}
```

## FROM: [RuoYi-Vue-framework-SecurityConfig](https://github.com/yangzongzhuan/RuoYi-Vue/blob/master/ruoyi-framework/src/main/java/com/ruoyi/framework/config/SecurityConfig.java)