### PR TITLE
Added escape of some keywords that `TypeHelper` missed

### DIFF
--- a/JavaToCSharp/TypeHelper.cs
+++ b/JavaToCSharp/TypeHelper.cs
@@ -17,6 +17,8 @@ namespace JavaToCSharp
             ["Boolean"] = "bool",
             ["ICloseable"] = "IDisposable",
             ["Integer"] = "int",
+            ["Long"] = "long",
+            ["Float"] = "float",
             ["String"] = "string",
             ["Object"] = "object",
 
@@ -83,6 +85,7 @@ namespace JavaToCSharp
                 case "float":
                 case "long":
                 case "double":
+                case "decimal":
                 case "in":
                 case "out":
                 case "byte":


### PR DESCRIPTION
- `Long/Float` Type-Name conversion is supported
  - fix: [RuoYi-common-model-LoginUser-Long-Type-Field]( https://github.com/yangzongzhuan/RuoYi-Vue/blob/324342800985a3e543a6ce308daeb219bdfbada0/ruoyi-common/src/main/java/com/ruoyi/common/core/domain/model/LoginUser.java#L22)
- Add `decimal` keyword in `EscapeIdentifier`
  - fix: [RuoYi-common-utils-HTMLFilter-name-decimal-method-parameter](https://github.com/yangzongzhuan/RuoYi-Vue/blob/7479ff4b06680cb7cca3a9cd987c4d6efb2d0032/ruoyi-common/src/main/java/com/ruoyi/common/utils/html/HTMLFilter.java#L175)