### PR TITLE
Fix string and char literal expression parsing

### DIFF
--- a/JavaToCSharp.Tests/VisitLiteralExpressionTests.cs
+++ b/JavaToCSharp.Tests/VisitLiteralExpressionTests.cs
@@ -1,0 +1,22 @@
+﻿using com.github.javaparser.ast.expr;
+using JavaToCSharp.Expressions;
+using Xunit;
+
+namespace LiteralExpressionTests
+{
+    public class VisitLiteralExpressionTests
+    {
+        [Fact]
+        public void VisitLiteralExpression_Char()
+        {
+            Assert.Equal("\n", ExpressionVisitor.VisitExpression(null, new CharLiteralExpr("\\n")).GetFirstToken().ValueText);
+        }
+
+        [Fact]
+        public void VisitLiteralExpression_String()
+        {
+            Assert.Equal("\\r", ExpressionVisitor.VisitExpression(null, new StringLiteralExpr("\\\\r")).GetFirstToken().ValueText);
+        }
+    }
+}
+

--- a/JavaToCSharp/Expressions/CharLiteralExpressionVisitor.cs
+++ b/JavaToCSharp/Expressions/CharLiteralExpressionVisitor.cs
@@ -1,12 +1,16 @@
 ﻿using com.github.javaparser.ast.expr;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Text.RegularExpressions;
 
 namespace JavaToCSharp.Expressions
 {
     public class CharLiteralExpressionVisitor : ExpressionVisitor<CharLiteralExpr>
     {
-        public override ExpressionSyntax Visit(ConversionContext context, CharLiteralExpr expr) => 
-            SyntaxFactory.LiteralExpression(SyntaxKind.CharacterLiteralExpression, SyntaxFactory.Literal(expr.toString().Trim('\'')[0]));
+        public override ExpressionSyntax Visit(ConversionContext context, CharLiteralExpr expr)
+        {
+            string value = Regex.Unescape(expr.getValue());
+            return SyntaxFactory.LiteralExpression(SyntaxKind.CharacterLiteralExpression, SyntaxFactory.Literal(value[0]));
+        }
     }
 }

--- a/JavaToCSharp/Expressions/CharLiteralExpressionVisitor.cs
+++ b/JavaToCSharp/Expressions/CharLiteralExpressionVisitor.cs
@@ -9,7 +9,7 @@ namespace JavaToCSharp.Expressions
     {
         public override ExpressionSyntax Visit(ConversionContext context, CharLiteralExpr expr)
         {
-            string value = Regex.Unescape(expr.getValue());
+            var value = Regex.Unescape(expr.getValue());
             return SyntaxFactory.LiteralExpression(SyntaxKind.CharacterLiteralExpression, SyntaxFactory.Literal(value[0]));
         }
     }

--- a/JavaToCSharp/Expressions/StringLiteralExpressionVisitor.cs
+++ b/JavaToCSharp/Expressions/StringLiteralExpressionVisitor.cs
@@ -1,6 +1,7 @@
 ﻿using com.github.javaparser.ast.expr;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Text.RegularExpressions;
 
 namespace JavaToCSharp.Expressions
 {
@@ -8,7 +9,7 @@ namespace JavaToCSharp.Expressions
     {
         public override ExpressionSyntax Visit(ConversionContext context, StringLiteralExpr expr)
         {
-            var value = expr.getValue();
+            var value = Regex.Unescape(expr.getValue());
             return SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal(value));
         }
     }


### PR DESCRIPTION
Fixes #20 and correctly parses escaped characters in a char literal.
`'\n'` would get translated to `'\\'` which is not correct.

Also includes some tests for the two fixes.