### PR TITLE
Convert interface extends

### DIFF
--- a/JavaToCSharp.Tests/ConvertInterfaceTests.cs
+++ b/JavaToCSharp.Tests/ConvertInterfaceTests.cs
@@ -33,6 +33,7 @@ public interface ResolvedValueDeclaration extends ResolvedDeclaration {
             var expectedCSharpCode = @"using Com.Github.Javaparser.Resolution;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 
@@ -50,9 +51,35 @@ namespace MyApp
         }
     }
 
-    public interface IResolvedValueDeclaration
+    public interface IResolvedValueDeclaration : ResolvedDeclaration
     {
         IResolvedType GetType();
+    }
+}"; 
+            
+            Assert.Equal(expectedCSharpCode, parsed);
+        }
+
+        [Fact]
+        public void Verify_Interface_Extends_Are_Converted()
+        {
+            var javaCode = @"public interface CharTermAttribute extends Attribute, CharSequence, Appendable {
+}";
+            var options = new JavaConversionOptions { StartInterfaceNamesWithI = true };
+            options.WarningEncountered += (_, eventArgs)
+                                              => Console.WriteLine("Line {0}: {1}", eventArgs.JavaLineNumber, eventArgs.Message);
+            var parsed = JavaToCSharpConverter.ConvertText(javaCode, options);
+
+            var expectedCSharpCode = @"using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+
+namespace MyApp
+{
+    public interface ICharTermAttribute : Attribute, CharSequence, Appendable
+    {
     }
 }"; 
             

--- a/JavaToCSharp/Declarations/ClassOrInterfaceDeclarationVisitor.cs
+++ b/JavaToCSharp/Declarations/ClassOrInterfaceDeclarationVisitor.cs
@@ -40,7 +40,6 @@ namespace JavaToCSharp.Declarations
             var classSyntax = SyntaxFactory.InterfaceDeclaration(newTypeName);
 
             var typeParams = javai.getTypeParameters().ToList<TypeParameter>();
-
             if (typeParams is {Count: > 0})
             {
                 classSyntax = classSyntax.AddTypeParameterListParameters(typeParams.Select(i => SyntaxFactory.TypeParameter(i.getName())).ToArray());
@@ -57,8 +56,16 @@ namespace JavaToCSharp.Declarations
             if (mods.HasFlag(Modifier.FINAL))
                 classSyntax = classSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.SealedKeyword));
 
-            var implements = javai.getImplements().ToList<ClassOrInterfaceType>();
+            var extends = javai.getExtends().ToList<ClassOrInterfaceType>();
+            if (extends != null)
+            {
+                foreach (var extend in extends)
+                {
+                    classSyntax = classSyntax.AddBaseListTypes(SyntaxFactory.SimpleBaseType(TypeHelper.GetSyntaxFromType(extend)));
+                }
+            }
 
+            var implements = javai.getImplements().ToList<ClassOrInterfaceType>();
             if (implements != null)
             {
                 foreach (var implement in implements)


### PR DESCRIPTION
Currently interface extends are not converted to their C# equivalent. This PR fixes it.