### PR TITLE
Java 9 Diamond Inner Class Test

### DIFF
--- a/JavaToCSharp.Tests/IntegrationTests.cs
+++ b/JavaToCSharp.Tests/IntegrationTests.cs
@@ -33,6 +33,7 @@ public class IntegrationTests
     [InlineData("Resources/Java7BasicTryWithResources.java")]
     [InlineData("Resources/Java7TryWithResources.java")]
     [InlineData("Resources/Java9TryWithResources.java")]
+    [InlineData("Resources/Java9DiamondOperatorInnerClass.java")]
     public void FullIntegrationTests(string filePath)
     {
         var options = new JavaConversionOptions

--- a/JavaToCSharp.Tests/IntegrationTests.cs
+++ b/JavaToCSharp.Tests/IntegrationTests.cs
@@ -17,6 +17,7 @@ public class IntegrationTests
     [InlineData("Resources/ArrayField.java")]
     [InlineData("Resources/SimilarityBase.java")]
     [InlineData("Resources/TestNumericDocValuesUpdates.java")]
+    [InlineData("Resources/Java9DiamondOperatorInnerClass.java")]
     public void GeneralSuccessfulConversionTest(string filePath)
     {
         var options = new JavaConversionOptions();
@@ -33,7 +34,6 @@ public class IntegrationTests
     [InlineData("Resources/Java7BasicTryWithResources.java")]
     [InlineData("Resources/Java7TryWithResources.java")]
     [InlineData("Resources/Java9TryWithResources.java")]
-    [InlineData("Resources/Java9DiamondOperatorInnerClass.java")]
     public void FullIntegrationTests(string filePath)
     {
         var options = new JavaConversionOptions

--- a/JavaToCSharp.Tests/Resources/Java9DiamondOperatorInnerClass.java
+++ b/JavaToCSharp.Tests/Resources/Java9DiamondOperatorInnerClass.java
@@ -1,5 +1,5 @@
-﻿/// Expect:
-/// - output: "1\n2\ntest\n"
+﻿// NOTE: This example when transformed to C# does not successfully compile yet, however we can somewhat successfully
+// parse it. Anonymous types always need a little bit of hand-holding after conversion anyways.
 package example;
 
 public class Program {

--- a/JavaToCSharp.Tests/Resources/Java9DiamondOperatorInnerClass.java
+++ b/JavaToCSharp.Tests/Resources/Java9DiamondOperatorInnerClass.java
@@ -1,0 +1,40 @@
+﻿/// Expect:
+/// - output: "1\n2\ntest\n"
+package example;
+
+public class Program {
+   public static void main(String[] args) {
+      Handler<Integer> intHandler = new Handler<>(1) {
+         @Override
+         public void handle() {
+            System.out.println(content);
+         }
+      };
+      intHandler.handle();
+      Handler<? extends Number> intHandler1 = new Handler<>(2) {
+         @Override
+         public void handle() {
+            System.out.println(content);
+         }
+      };
+      intHandler1.handle();
+      Handler<?> handler = new Handler<>("test") {
+         @Override
+         public void handle() {
+            System.out.println(content);
+         }
+      };
+
+      handler.handle();    
+   }  
+}
+
+abstract class Handler<T> {
+   public T content;
+
+   public Handler(T content) {
+      this.content = content; 
+   }
+   
+   abstract void handle();
+}


### PR DESCRIPTION
This adds a unit test for the Java 9 diamond operator in inner classes syntax. It does not successfully build and run so for now this is a conversion test only. Anonymous types currently require a bit of manual clean-up after converted usually anyways. Maybe there's a way we could better do this, but things like `<? extends Number>` might be more difficult.