### PR TITLE
Transformer: Support converting default/private interface methods, #53

### DIFF
--- a/JavaToCSharp.Tests/ConvertInterfaceTests.cs
+++ b/JavaToCSharp.Tests/ConvertInterfaceTests.cs
@@ -41,7 +41,10 @@ public class ConvertInterfaceTests
             {
                 public interface IResolvedType
                 {
-                    bool IsArray();
+                    bool IsArray()
+                    {
+                        return false;
+                    }
                 }
 
                 public class InferenceVariableType : IResolvedType

--- a/JavaToCSharp.Tests/IntegrationTests.cs
+++ b/JavaToCSharp.Tests/IntegrationTests.cs
@@ -52,6 +52,7 @@ public class IntegrationTests
     [InlineData("Resources/Java7BasicTryWithResources.java")]
     [InlineData("Resources/Java7TryWithResources.java")]
     [InlineData("Resources/Java9TryWithResources.java")]
+    [InlineData("Resources/Java9PrivateInterfaceMethods.java")]
     public void FullIntegrationTests(string filePath)
     {
         var options = new JavaConversionOptions

--- a/JavaToCSharp.Tests/Resources/Java9PrivateInterfaceMethods.java
+++ b/JavaToCSharp.Tests/Resources/Java9PrivateInterfaceMethods.java
@@ -1,0 +1,22 @@
+﻿/// Expect:
+/// - output: "Hello world!\n"
+package example;
+
+public class Program {
+    public static void main(String[] args) {
+        InterfaceWithPrivateMethod implementation = new Implementation();
+        implementation.defaultMethod();
+    }
+}
+
+class Implementation implements InterfaceWithPrivateMethod {
+}
+
+interface InterfaceWithPrivateMethod {
+    default void defaultMethod() {
+        privateMethod();
+    }
+    private void privateMethod() {
+        System.out.println("Hello world!");
+    }
+}

--- a/JavaToCSharp/Declarations/ClassOrInterfaceDeclarationVisitor.cs
+++ b/JavaToCSharp/Declarations/ClassOrInterfaceDeclarationVisitor.cs
@@ -50,15 +50,15 @@ public class ClassOrInterfaceDeclarationVisitor : BodyDeclarationVisitor<ClassOr
             classSyntax = classSyntax.AddTypeParameterListParameters(typeParams.Select(i => SyntaxFactory.TypeParameter(i.getNameAsString())).ToArray());
         }
 
-        var mods = javai.getModifiers().ToList<Modifier>() ?? new List<Modifier>();
+        var mods = javai.getModifiers().ToModifierKeywordSet();
 
-        if (mods.Any(i => i.getKeyword() == Modifier.Keyword.PRIVATE))
+        if (mods.Contains(Modifier.Keyword.PRIVATE))
             classSyntax = classSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.PrivateKeyword));
-        if (mods.Any(i => i.getKeyword() == Modifier.Keyword.PROTECTED))
+        if (mods.Contains(Modifier.Keyword.PROTECTED))
             classSyntax = classSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.ProtectedKeyword));
-        if (mods.Any(i => i.getKeyword() == Modifier.Keyword.PUBLIC))
+        if (mods.Contains(Modifier.Keyword.PUBLIC))
             classSyntax = classSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword));
-        if (mods.Any(i => i.getKeyword() == Modifier.Keyword.FINAL))
+        if (mods.Contains(Modifier.Keyword.FINAL))
             classSyntax = classSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.SealedKeyword));
 
         var extends = javai.getExtendedTypes().ToList<ClassOrInterfaceType>();
@@ -113,17 +113,17 @@ public class ClassOrInterfaceDeclarationVisitor : BodyDeclarationVisitor<ClassOr
             classSyntax = classSyntax.AddTypeParameterListParameters(typeParams.Select(i => SyntaxFactory.TypeParameter(i.getNameAsString())).ToArray());
         }
 
-        var mods = javac.getModifiers().ToList<Modifier>() ?? new List<Modifier>();
+        var mods = javac.getModifiers().ToModifierKeywordSet();
 
-        if (mods.Any(i => i.getKeyword() == Modifier.Keyword.PRIVATE))
+        if (mods.Contains(Modifier.Keyword.PRIVATE))
             classSyntax = classSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.PrivateKeyword));
-        if (mods.Any(i => i.getKeyword() == Modifier.Keyword.PROTECTED))
+        if (mods.Contains(Modifier.Keyword.PROTECTED))
             classSyntax = classSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.ProtectedKeyword));
-        if (mods.Any(i => i.getKeyword() == Modifier.Keyword.PUBLIC))
+        if (mods.Contains(Modifier.Keyword.PUBLIC))
             classSyntax = classSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword));
-        if (mods.Any(i => i.getKeyword() == Modifier.Keyword.ABSTRACT))
+        if (mods.Contains(Modifier.Keyword.ABSTRACT))
             classSyntax = classSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.AbstractKeyword));
-        if (mods.Any(i => i.getKeyword() == Modifier.Keyword.FINAL))
+        if (mods.Contains(Modifier.Keyword.FINAL))
             classSyntax = classSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.SealedKeyword));
 
         var extends = javac.getExtendedTypes().ToList<ClassOrInterfaceType>() ?? new List<ClassOrInterfaceType>();

--- a/JavaToCSharp/Declarations/ConstructorDeclarationVisitor.cs
+++ b/JavaToCSharp/Declarations/ConstructorDeclarationVisitor.cs
@@ -30,13 +30,13 @@ public class ConstructorDeclarationVisitor : BodyDeclarationVisitor<ConstructorD
         var ctorSyntax = SyntaxFactory.ConstructorDeclaration(identifier)
                                       .WithLeadingTrivia(SyntaxFactory.CarriageReturnLineFeed);
 
-        var mods = ctorDecl.getModifiers().ToList<Modifier>() ?? new List<Modifier>();
+        var mods = ctorDecl.getModifiers().ToModifierKeywordSet();
 
-        if (mods.Any(i => i.getKeyword() == Modifier.Keyword.PUBLIC))
+        if (mods.Contains(Modifier.Keyword.PUBLIC))
             ctorSyntax = ctorSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword));
-        if (mods.Any(i => i.getKeyword() == Modifier.Keyword.PROTECTED))
+        if (mods.Contains(Modifier.Keyword.PROTECTED))
             ctorSyntax = ctorSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.ProtectedKeyword));
-        if (mods.Any(i => i.getKeyword() == Modifier.Keyword.PRIVATE))
+        if (mods.Contains(Modifier.Keyword.PRIVATE))
             ctorSyntax = ctorSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.PrivateKeyword));
 
         var parameters = ctorDecl.getParameters().ToList<Parameter>();

--- a/JavaToCSharp/Declarations/EnumDeclarationVisitor.cs
+++ b/JavaToCSharp/Declarations/EnumDeclarationVisitor.cs
@@ -84,13 +84,13 @@ public class EnumDeclarationVisitor : BodyDeclarationVisitor<EnumDeclaration>
             classSyntax = classSyntax.AddMembers(enumMembers.ToArray());
         }
 
-        var mods = javai.getModifiers().ToList<Modifier>() ?? new List<Modifier>();
+        var mods = javai.getModifiers().ToModifierKeywordSet();
         
-        if (mods.Any(i => i.getKeyword() == Modifier.Keyword.PRIVATE))
+        if (mods.Contains(Modifier.Keyword.PRIVATE))
             classSyntax = classSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.PrivateKeyword));
-        if (mods.Any(i => i.getKeyword() == Modifier.Keyword.PROTECTED))
+        if (mods.Contains(Modifier.Keyword.PROTECTED))
             classSyntax = classSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.ProtectedKeyword));
-        if (mods.Any(i => i.getKeyword() == Modifier.Keyword.PUBLIC))
+        if (mods.Contains(Modifier.Keyword.PUBLIC))
             classSyntax = classSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword));
 
         return classSyntax.WithJavaComments(context, javai);

--- a/JavaToCSharp/Declarations/FieldDeclarationVisitor.cs
+++ b/JavaToCSharp/Declarations/FieldDeclarationVisitor.cs
@@ -60,19 +60,19 @@ public class FieldDeclarationVisitor : BodyDeclarationVisitor<FieldDeclaration>
                 SyntaxFactory.ParseTypeName(typeName),
                 SyntaxFactory.SeparatedList(variables, Enumerable.Repeat(SyntaxFactory.Token(SyntaxKind.CommaToken), variables.Count - 1))));
 
-        var mods = fieldDecl.getModifiers().ToList<Modifier>();
+        var mods = fieldDecl.getModifiers().ToModifierKeywordSet();
 
-        if (mods.Any(i => i.getKeyword() == Modifier.Keyword.PUBLIC))
+        if (mods.Contains(Modifier.Keyword.PUBLIC))
             fieldSyntax = fieldSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword));
-        if (mods.Any(i => i.getKeyword() == Modifier.Keyword.PROTECTED))
+        if (mods.Contains(Modifier.Keyword.PROTECTED))
             fieldSyntax = fieldSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.ProtectedKeyword));
-        if (mods.Any(i => i.getKeyword() == Modifier.Keyword.PRIVATE))
+        if (mods.Contains(Modifier.Keyword.PRIVATE))
             fieldSyntax = fieldSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.PrivateKeyword));
-        if (mods.Any(i => i.getKeyword() == Modifier.Keyword.STATIC))
+        if (mods.Contains(Modifier.Keyword.STATIC))
             fieldSyntax = fieldSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.StaticKeyword));
-        if (mods.Any(i => i.getKeyword() == Modifier.Keyword.FINAL))
+        if (mods.Contains(Modifier.Keyword.FINAL))
             fieldSyntax = fieldSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword));
-        if (mods.Any(i => i.getKeyword() == Modifier.Keyword.VOLATILE))
+        if (mods.Contains(Modifier.Keyword.VOLATILE))
             fieldSyntax = fieldSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.VolatileKeyword));
 
         return fieldSyntax;

--- a/JavaToCSharp/Extensions.cs
+++ b/JavaToCSharp/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using java.util;
 using Microsoft.CodeAnalysis;
 using JavaAst = com.github.javaparser.ast;
@@ -60,4 +61,8 @@ public static class Extensions
             ? optional.get() as T ??
               throw new InvalidOperationException($"Optional did not convert to {typeof(T)}")
             : throw new InvalidOperationException("Required optional did not have a value");
+
+    public static ISet<JavaAst.Modifier.Keyword> ToModifierKeywordSet(this JavaAst.NodeList nodeList)
+        => nodeList.ToList<JavaAst.Modifier>()?.Select(i => i.getKeyword()).ToHashSet() 
+           ?? new HashSet<JavaAst.Modifier.Keyword>();
 }


### PR DESCRIPTION
This converts interface methods with a body, such as default and private interface methods, to C# 8 interface methods with bodies.

Also, this cleans up some use of modifier keyword determination that was messy as a reult of the JavaParser upgrade.