### PR TITLE
Tests: Add test for Java 10 type inference, #53

### DIFF
--- a/JavaToCSharp.Tests/IntegrationTests.cs
+++ b/JavaToCSharp.Tests/IntegrationTests.cs
@@ -53,6 +53,7 @@ public class IntegrationTests
     [InlineData("Resources/Java7TryWithResources.java")]
     [InlineData("Resources/Java9TryWithResources.java")]
     [InlineData("Resources/Java9PrivateInterfaceMethods.java")]
+    [InlineData("Resources/Java10TypeInference.java")]
     public void FullIntegrationTests(string filePath)
     {
         var options = new JavaConversionOptions

--- a/JavaToCSharp.Tests/Resources/Java10TypeInference.java
+++ b/JavaToCSharp.Tests/Resources/Java10TypeInference.java
@@ -1,0 +1,10 @@
+﻿/// Expect:
+/// - output: "Hello world!\n"
+package example;
+
+public class Program {
+    public static void main(String[] args) {
+        var message = "Hello world!";
+        System.out.println(message);
+    }
+}


### PR DESCRIPTION
This was already accidentally supported, but now we're making our support for type inference explicit and under test.