### PR TITLE
Tests: Add parse test for Java 11 lambda parameter type inference, #53

### DIFF
--- a/JavaToCSharp.Tests/IntegrationTests.cs
+++ b/JavaToCSharp.Tests/IntegrationTests.cs
@@ -18,6 +18,7 @@ public class IntegrationTests
     [InlineData("Resources/SimilarityBase.java")]
     [InlineData("Resources/TestNumericDocValuesUpdates.java")]
     [InlineData("Resources/Java9DiamondOperatorInnerClass.java")]
+    [InlineData("Resources/Java11LambdaInference.java")]
     public void GeneralSuccessfulConversionTest(string filePath)
     {
         var options = new JavaConversionOptions

--- a/JavaToCSharp.Tests/Resources/Java11LambdaInference.java
+++ b/JavaToCSharp.Tests/Resources/Java11LambdaInference.java
@@ -1,0 +1,14 @@
+﻿// NOTE: this is currently just a successfully-parses test. It does handle `var` successfully through to the C# code,
+// but the `import`, `BiFunction`, and `.apply` calls are not successfully translated. Some additional options in the
+// conversion process such as skipping incoming imports, BiFunction -> Func, and somehow converting `.Apply` to
+// `.Invoke` (without being a global always-on translation) would make this work in the full integration test. 
+package example;
+
+import java.util.function.BiFunction;
+
+public class Java11LambdaParameterTypeInference {
+    public static void main(String[] args) {
+        BiFunction<Integer, Integer, Integer> add = (var a, var b) -> a + b;
+        System.out.println(add.apply(1, 2));
+    }
+}


### PR DESCRIPTION
Just like regular type inference for Java 10, we already accidentally supported this since `var` is the same in both languages. In this case, we cannot make this a full integration test due to some issues noted in the test file comments.