### PR TITLE
Fix issue with array creation expressions, #38

### DIFF
--- a/JavaToCSharp.Tests/IntegrationTests.cs
+++ b/JavaToCSharp.Tests/IntegrationTests.cs
@@ -55,6 +55,7 @@ public class IntegrationTests
     [InlineData("Resources/Java9TryWithResources.java")]
     [InlineData("Resources/Java9PrivateInterfaceMethods.java")]
     [InlineData("Resources/Java10TypeInference.java")]
+    [InlineData("Resources/NewArrayLiteralBug.java")]
     public void FullIntegrationTests(string filePath)
     {
         var options = new JavaConversionOptions

--- a/JavaToCSharp.Tests/Resources/NewArrayLiteralBug.java
+++ b/JavaToCSharp.Tests/Resources/NewArrayLiteralBug.java
@@ -1,0 +1,17 @@
+﻿/// Expect:
+/// - output: "0\n1\n"
+package example;
+
+// see issue #38
+public class Program {
+    static float[] mFirstByteFreq;
+    public static void main(String[] args) {
+        mFirstByteFreq = new float[] { 
+            0.000000f,
+            1.000000f
+        };
+        
+        System.out.println(mFirstByteFreq[0]);
+        System.out.println(mFirstByteFreq[1]);
+    }
+}

--- a/JavaToCSharp/Expressions/ArrayCreationExpressionVisitor.cs
+++ b/JavaToCSharp/Expressions/ArrayCreationExpressionVisitor.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using com.github.javaparser.ast;
+﻿using com.github.javaparser.ast;
 using com.github.javaparser.ast.expr;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -21,26 +19,34 @@ public class ArrayCreationExpressionVisitor : ExpressionVisitor<ArrayCreationExp
 
         if (rankDimensions != null)
         {
-            var expressionSyntaxes = rankDimensions.Select(dimension => VisitExpression(context, dimension.getDimension().FromOptional<Expression>()))
-                                                   .Where(syntax => syntax != null);
+            var expressionSyntaxes = rankDimensions.Select(dimension =>
+                    VisitExpression(context, dimension.getDimension().FromOptional<Expression>()))
+                .Where(syntax => syntax != null);
             rankSyntaxes.AddRange(expressionSyntaxes!);
         }
 
+        var rankSpecifier = rankDimensions?.Count > 0 && rankSyntaxes.Count == 0 
+                ? SyntaxFactory.ArrayRankSpecifier(SyntaxFactory.SingletonSeparatedList<ExpressionSyntax>(SyntaxFactory.OmittedArraySizeExpression()))
+                : SyntaxFactory.ArrayRankSpecifier(SyntaxFactory.SeparatedList(rankSyntaxes, Enumerable.Repeat(SyntaxFactory.Token(SyntaxKind.CommaToken), rankSyntaxes.Count - 1)));
+
         if (initializer == null)
             return SyntaxFactory.ArrayCreationExpression(SyntaxFactory.ArrayType(SyntaxFactory.ParseTypeName(type)))
-                .AddTypeRankSpecifiers(SyntaxFactory.ArrayRankSpecifier(SyntaxFactory.SeparatedList(rankSyntaxes, Enumerable.Repeat(SyntaxFactory.Token(SyntaxKind.CommaToken), rankSyntaxes.Count - 1))));
+                .AddTypeRankSpecifiers(rankSpecifier);
 
         // todo: support multi-dimensional and jagged arrays
 
         var values = initializer.getValues()?.ToList<Expression>() ?? new List<Expression>();
         var syntaxes = values.Select(value => VisitExpression(context, value))
-                             .Where(syntax => syntax != null)!
-                             .ToList<ExpressionSyntax>();
+            .Where(syntax => syntax != null)!
+            .ToList<ExpressionSyntax>();
         var initSyntax =
-            syntaxes.Any() ?
-            SyntaxFactory.InitializerExpression(SyntaxKind.ArrayInitializerExpression, SyntaxFactory.SeparatedList(syntaxes, Enumerable.Repeat(SyntaxFactory.Token(SyntaxKind.CommaToken), syntaxes.Count - 1))) :
-            SyntaxFactory.InitializerExpression(SyntaxKind.ArrayInitializerExpression);
+            syntaxes.Any()
+                ? SyntaxFactory.InitializerExpression(SyntaxKind.ArrayInitializerExpression,
+                    SyntaxFactory.SeparatedList(syntaxes,
+                        Enumerable.Repeat(SyntaxFactory.Token(SyntaxKind.CommaToken), syntaxes.Count - 1)))
+                : SyntaxFactory.InitializerExpression(SyntaxKind.ArrayInitializerExpression);
 
-        return SyntaxFactory.ArrayCreationExpression(SyntaxFactory.ArrayType(SyntaxFactory.ParseTypeName(type)), initSyntax);
+        return SyntaxFactory.ArrayCreationExpression(SyntaxFactory.ArrayType(SyntaxFactory.ParseTypeName(type)), initSyntax)
+            .AddTypeRankSpecifiers(rankSpecifier);
     }
 }


### PR DESCRIPTION
Fixes generated C# for array creation expressions. Was (incorrectly) i.e. `new float { ... }` when it should be `new float[] { ... }`