### PR TITLE
Support (almost) all options in the CLI app, #58

### DIFF
--- a/JavaToCSharpCli/JavaToCSharpCli.csproj
+++ b/JavaToCSharpCli/JavaToCSharpCli.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\JavaToCSharp\JavaToCSharp.csproj" />

--- a/JavaToCSharpCli/Program.cs
+++ b/JavaToCSharpCli/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.CommandLine;
+using System.CommandLine.Invocation;
 using JavaToCSharp;
 using Microsoft.Extensions.Logging;
 
@@ -12,6 +13,53 @@ public class Program
     private static readonly ILoggerFactory _loggerFactory;
     private static readonly ILogger _logger;
 
+    private static readonly Option<bool> _includeUsingsOption = new(
+        name: "--include-usings",
+        description: "Include using directives in output",
+        getDefaultValue: () => true);
+    
+    private static readonly Option<bool> _includeNamespaceOption = new(
+        name: "--include-namespace",
+        description: "Include namespace in output",
+        getDefaultValue: () => true);
+    
+    private static readonly Option<bool> _includeCommentsOption = new(
+        name: "--include-comments",
+        description: "Include comments in output",
+        getDefaultValue: () => true);
+    
+    private static readonly Option<bool> _useDebugAssertOption = new(
+        name: "--use-debug-assert",
+        description: "Use Debug.Assert for asserts",
+        getDefaultValue: () => false);
+    
+    private static readonly Option<bool> _startInterfaceNamesWithIOption = new(
+        name: "--start-interface-names-with-i",
+        description: "Prefix interface names with the letter I",
+        getDefaultValue: () => true);
+    
+    private static readonly Option<bool> _commentUnrecognizedCodeOption = new(
+        name: "--comment-unrecognized-code",
+        description: "Include unrecognized code in output as commented-out code",
+        getDefaultValue: () => true);
+    
+    private static readonly Option<bool> _systemOutToConsoleOption = new(
+        name: "--system-out-to-console",
+        description: "Convert System.out calls to Console",
+        getDefaultValue: () => false);
+    
+    private static readonly Option<bool> _clearDefaultUsingsOption = new(
+        name: "--clear-usings",
+        description: "Remove all default usings provided by this app",
+        getDefaultValue: () => false);
+
+    private static readonly Option<List<string>> _addUsingsOption = new(
+        name: "--add-using",
+        description: "Adds a using directive to the collection of usings")
+    {
+        ArgumentHelpName = "namespace"
+    };
+
     static Program()
     {
         _loggerFactory = LoggerFactory.Create(builder =>
@@ -21,42 +69,23 @@ public class Program
 
     public static async Task Main(string[] args)
     {
-        var inputOption = new Option<FileSystemInfo?>(
-            name: "--input",
-            description: "A Java source code file or directory to convert");
+        var rootCommand = new RootCommand("Java to C# Converter")
+        {
+            Description = "A syntactic transformer of source code from Java to C#."
+        };
 
-        var outputOption = new Option<FileSystemInfo?>(
-            name: "--output",
-            description: "Path to a file or directory for the C# output");
-
-        var rootCommand = new RootCommand("Java to C# Converter");
-        rootCommand.AddOption(inputOption);
-        rootCommand.AddOption(outputOption);
-
-        rootCommand.SetHandler((input, output) =>
-            {
-                if (input is FileInfo inputFile)
-                {
-                    if (output is not FileInfo outputFile)
-                    {
-                        _logger.LogError("Expected a file, not a directory, as output");
-                        return;
-                    }
-
-                    ConvertToCSharpFile(inputFile, outputFile);
-                }
-                else if (input is DirectoryInfo inputDirectory)
-                {
-                    if (output is not DirectoryInfo outputDirectory)
-                    {
-                        _logger.LogError("Expected a directory, not a file, as output");
-                        return;
-                    }
-
-                    ConvertToCSharpDir(inputDirectory, outputDirectory);
-                }
-            },
-            inputOption, outputOption);
+        rootCommand.AddCommand(CreateFileCommand());
+        rootCommand.AddCommand(CreateDirectoryCommand());
+        
+        rootCommand.AddGlobalOption(_includeUsingsOption);
+        rootCommand.AddGlobalOption(_includeNamespaceOption);
+        rootCommand.AddGlobalOption(_includeCommentsOption);
+        rootCommand.AddGlobalOption(_useDebugAssertOption);
+        rootCommand.AddGlobalOption(_startInterfaceNamesWithIOption);
+        rootCommand.AddGlobalOption(_commentUnrecognizedCodeOption);
+        rootCommand.AddGlobalOption(_systemOutToConsoleOption);
+        rootCommand.AddGlobalOption(_clearDefaultUsingsOption);
+        rootCommand.AddGlobalOption(_addUsingsOption);
 
         await rootCommand.InvokeAsync(args);
 
@@ -64,7 +93,88 @@ public class Program
         _loggerFactory.Dispose();
     }
 
-    private static void ConvertToCSharpDir(DirectoryInfo inputDirectory, DirectoryInfo outputDirectory)
+    private static Command CreateFileCommand()
+    {
+        var inputArgument = new Argument<FileInfo>(
+            name: "input",
+            description: "A Java source code file to convert");
+
+        var outputArgument = new Argument<FileInfo?>(
+            name: "output",
+            description: "Path to place the C# output file, or stdout if omitted",
+            getDefaultValue: () => null);
+
+        var fileCommand = new Command("file", "Convert a Java file to C#");
+        fileCommand.AddArgument(inputArgument);
+        fileCommand.AddArgument(outputArgument);
+
+        fileCommand.SetHandler(context =>
+        {
+            var input = context.ParseResult.GetValueForArgument(inputArgument);
+            var output = context.ParseResult.GetValueForArgument(outputArgument);
+
+            var options = GetJavaConversionOptions(context);
+
+            ConvertToCSharpFile(input, output, options);
+        });
+
+        return fileCommand;
+    }
+
+    private static JavaConversionOptions GetJavaConversionOptions(InvocationContext context)
+    {
+        var options = new JavaConversionOptions
+        {
+            IncludeUsings = context.ParseResult.GetValueForOption(_includeUsingsOption),
+            IncludeComments = context.ParseResult.GetValueForOption(_includeCommentsOption),
+            IncludeNamespace = context.ParseResult.GetValueForOption(_includeNamespaceOption),
+            ConvertSystemOutToConsole = context.ParseResult.GetValueForOption(_systemOutToConsoleOption),
+            StartInterfaceNamesWithI = context.ParseResult.GetValueForOption(_startInterfaceNamesWithIOption),
+            UseDebugAssertForAsserts = context.ParseResult.GetValueForOption(_useDebugAssertOption),
+            UseUnrecognizedCodeToComment = context.ParseResult.GetValueForOption(_commentUnrecognizedCodeOption)
+        };
+
+        if (context.ParseResult.GetValueForOption(_clearDefaultUsingsOption))
+        {
+            options.ClearUsings();
+        }
+
+        foreach (string ns in context.ParseResult.GetValueForOption(_addUsingsOption) ?? new List<string>())
+        {
+            options.AddUsing(ns);
+        }
+        
+        return options;
+    }
+
+    private static Command CreateDirectoryCommand()
+    {
+        var inputArgument = new Argument<DirectoryInfo>(
+            name: "input",
+            description: "A directory containing Java source code files to convert");
+
+        var outputArgument = new Argument<DirectoryInfo>(
+            name: "output",
+            description: "Path to place the C# output files");
+
+        var dirCommand = new Command("dir", "Convert a directory containing Java files to C#");
+        dirCommand.AddArgument(inputArgument);
+        dirCommand.AddArgument(outputArgument);
+
+        dirCommand.SetHandler(context =>
+        {
+            var input = context.ParseResult.GetValueForArgument(inputArgument);
+            var output = context.ParseResult.GetValueForArgument(outputArgument);
+
+            var options = GetJavaConversionOptions(context);
+
+            ConvertToCSharpDir(input, output, options);
+        });
+
+        return dirCommand;
+    }
+
+    private static void ConvertToCSharpDir(DirectoryInfo inputDirectory, DirectoryInfo outputDirectory, JavaConversionOptions options)
     {
         if (inputDirectory.Exists)
         {
@@ -83,6 +193,7 @@ public class Program
 
                 ConvertToCSharpFile(f,
                     new FileInfo(Path.Combine(outputDirectory.FullName, Path.ChangeExtension(f.Name, ".cs"))),
+                    options,
                     false);
             }
         }
@@ -90,35 +201,59 @@ public class Program
             _logger.LogError("Java input folder {path} doesn't exist!", inputDirectory);
     }
 
-    private static void ConvertToCSharpFile(FileSystemInfo inputFile, FileSystemInfo outputFile, bool overwrite = true)
+    private static void ConvertToCSharpFile(FileSystemInfo inputFile, FileSystemInfo? outputFile, JavaConversionOptions options, bool overwrite = true)
     {
-        if (!overwrite && outputFile.Exists)
+        if (!overwrite && outputFile is { Exists: true })
             _logger.LogInformation("{outputFilePath} exists, skip to next.", outputFile);
         else if (inputFile.Exists)
         {
             try
             {
                 string javaText = File.ReadAllText(inputFile.FullName);
-                var options = new JavaConversionOptions();
 
                 options.WarningEncountered += (_, eventArgs) =>
                 {
-                    _logger.LogWarning("Line {JavaLineNumber}: {Message}", eventArgs.JavaLineNumber, eventArgs.Message);
-                    File.AppendAllText(Path.ChangeExtension(outputFile.FullName, ".warning"),
+                    if (outputFile != null)
+                    {
+                        _logger.LogWarning("Line {JavaLineNumber}: {Message}", eventArgs.JavaLineNumber,
+                            eventArgs.Message);
+                    }
+
+                    OutputFileOrPrint(outputFile != null ? Path.ChangeExtension(outputFile.FullName, ".warning") : null,
                         eventArgs.Message + Environment.NewLine);
                 };
 
                 string? parsed = JavaToCSharpConverter.ConvertText(javaText, options);
-                File.WriteAllText(outputFile.FullName, parsed);
-                _logger.LogInformation("{filePath} converted!", inputFile.Name);
+                OutputFileOrPrint(outputFile?.FullName, parsed ?? string.Empty);
+
+                if (outputFile != null)
+                {
+                    _logger.LogInformation("{filePath} converted!", inputFile.Name);
+                }
             }
             catch (Exception ex)
             {
                 _logger.LogError("{filePath} failed! {type}: {message}", inputFile.Name, ex.GetType().Name, ex);
-                File.WriteAllText(Path.ChangeExtension(outputFile.FullName, ".error"), ex.ToString());
+
+                if (outputFile != null)
+                {
+                    File.WriteAllText(Path.ChangeExtension(outputFile.FullName, ".error"), ex.ToString());
+                }
             }
         }
         else
             _logger.LogError("Java input file {filePath} doesn't exist!", inputFile.FullName);
+    }
+
+    private static void OutputFileOrPrint(string? fileName, string contents)
+    {
+        if (fileName == null)
+        {
+            Console.Out.WriteLine(contents);
+        }
+        else
+        {
+            File.WriteAllText(fileName, contents);
+        }
     }
 }

--- a/JavaToCSharpCli/Program.cs
+++ b/JavaToCSharpCli/Program.cs
@@ -1,111 +1,124 @@
-﻿using JavaToCSharp;
+﻿using System.CommandLine;
+using JavaToCSharp;
 using Microsoft.Extensions.Logging;
 
 namespace JavaToCSharpCli;
 
+/// <summary>
+/// The main JavaToCSharpCli program class.
+/// </summary>
 public class Program
 {
+    private static readonly ILoggerFactory _loggerFactory;
     private static readonly ILogger _logger;
 
     static Program()
     {
-        var loggerFactory =
-            LoggerFactory.Create(builder => builder.AddSimpleConsole().SetMinimumLevel(LogLevel.Information));
-        _logger = loggerFactory.CreateLogger<Program>();
+        _loggerFactory = LoggerFactory.Create(builder =>
+            builder.AddSimpleConsole().SetMinimumLevel(LogLevel.Information));
+        _logger = _loggerFactory.CreateLogger<Program>();
     }
 
-    public static void Main(string[] args)
+    public static async Task Main(string[] args)
     {
-        try
-        {
-            if (args.Length < 3)
-                ShowHelp();
-            else
-                switch (args[0])
+        var inputOption = new Option<FileSystemInfo?>(
+            name: "--input",
+            description: "A Java source code file or directory to convert");
+
+        var outputOption = new Option<FileSystemInfo?>(
+            name: "--output",
+            description: "Path to a file or directory for the C# output");
+
+        var rootCommand = new RootCommand("Java to C# Converter");
+        rootCommand.AddOption(inputOption);
+        rootCommand.AddOption(outputOption);
+
+        rootCommand.SetHandler((input, output) =>
+            {
+                if (input is FileInfo inputFile)
                 {
-                    case "-f":
-                        ConvertToCSharpFile(args[1], args[2]);
-                        break;
-                    case "-d":
-                        ConvertToCSharpDir(args[1], args[2]);
-                        break;
-                    default:
-                        ShowHelp();
-                        break;
-                }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error: {Message}", ex.Message);
-        }
+                    if (output is not FileInfo outputFile)
+                    {
+                        _logger.LogError("Expected a file, not a directory, as output");
+                        return;
+                    }
 
-        // allow logger background thread to flush
-        Thread.Sleep(TimeSpan.FromSeconds(1));
+                    ConvertToCSharpFile(inputFile, outputFile);
+                }
+                else if (input is DirectoryInfo inputDirectory)
+                {
+                    if (output is not DirectoryInfo outputDirectory)
+                    {
+                        _logger.LogError("Expected a directory, not a file, as output");
+                        return;
+                    }
+
+                    ConvertToCSharpDir(inputDirectory, outputDirectory);
+                }
+            },
+            inputOption, outputOption);
+
+        await rootCommand.InvokeAsync(args);
+
+        // flush logs
+        _loggerFactory.Dispose();
     }
 
-    private static void ConvertToCSharpDir(string folderPath, string outputFolderPath)
+    private static void ConvertToCSharpDir(DirectoryInfo inputDirectory, DirectoryInfo outputDirectory)
     {
-        if (Directory.Exists(folderPath))
+        if (inputDirectory.Exists)
         {
-            var input = new DirectoryInfo(folderPath);
-            foreach (var f in input.GetFiles("*.java", SearchOption.AllDirectories))
+            foreach (var f in inputDirectory.GetFiles("*.java", SearchOption.AllDirectories))
             {
                 string? directoryName = f.DirectoryName;
                 if (string.IsNullOrWhiteSpace(directoryName))
                 {
                     continue;
                 }
-                
-                string newFolderPath = directoryName.Replace(folderPath, outputFolderPath, StringComparison.OrdinalIgnoreCase);
-                if (!Directory.Exists(newFolderPath))
+
+                if (!outputDirectory.Exists)
                 {
-                    Directory.CreateDirectory(newFolderPath);
+                    outputDirectory.Create();
                 }
 
-                ConvertToCSharpFile(f.FullName,
-                                    Path.Combine(newFolderPath, Path.ChangeExtension(f.Name, ".cs")),
-                                    false);
+                ConvertToCSharpFile(f,
+                    new FileInfo(Path.Combine(outputDirectory.FullName, Path.ChangeExtension(f.Name, ".cs"))),
+                    false);
             }
         }
         else
-            _logger.LogError("Java input folder {path} doesn't exist!", folderPath);
+            _logger.LogError("Java input folder {path} doesn't exist!", inputDirectory);
     }
 
-    private static void ConvertToCSharpFile(string filePath, string outputFilePath, bool overwrite = true)
+    private static void ConvertToCSharpFile(FileSystemInfo inputFile, FileSystemInfo outputFile, bool overwrite = true)
     {
-        if (!overwrite && File.Exists(outputFilePath))
-            _logger.LogInformation("{outputFilePath} exists, skip to next.", outputFilePath);
-        else if (File.Exists(filePath))
+        if (!overwrite && outputFile.Exists)
+            _logger.LogInformation("{outputFilePath} exists, skip to next.", outputFile);
+        else if (inputFile.Exists)
         {
             try
             {
-                string javaText = File.ReadAllText(filePath);
+                string javaText = File.ReadAllText(inputFile.FullName);
                 var options = new JavaConversionOptions();
 
                 options.WarningEncountered += (_, eventArgs) =>
-                                              {
-                                                  _logger.LogWarning("Line {JavaLineNumber}: {Message}", eventArgs.JavaLineNumber, eventArgs.Message);
-                                                  File.AppendAllText(Path.ChangeExtension(outputFilePath, ".warning"), eventArgs.Message + Environment.NewLine);
-                                              };
+                {
+                    _logger.LogWarning("Line {JavaLineNumber}: {Message}", eventArgs.JavaLineNumber, eventArgs.Message);
+                    File.AppendAllText(Path.ChangeExtension(outputFile.FullName, ".warning"),
+                        eventArgs.Message + Environment.NewLine);
+                };
 
                 string? parsed = JavaToCSharpConverter.ConvertText(javaText, options);
-                File.WriteAllText(outputFilePath, parsed);
-                _logger.LogInformation("{filePath} converted!", filePath);
+                File.WriteAllText(outputFile.FullName, parsed);
+                _logger.LogInformation("{filePath} converted!", inputFile.Name);
             }
             catch (Exception ex)
             {
-                _logger.LogError("{filePath} failed! {type}: {message}", filePath, ex.GetType().Name, ex);
-                File.WriteAllText(Path.ChangeExtension(outputFilePath, ".error"), ex.ToString());
+                _logger.LogError("{filePath} failed! {type}: {message}", inputFile.Name, ex.GetType().Name, ex);
+                File.WriteAllText(Path.ChangeExtension(outputFile.FullName, ".error"), ex.ToString());
             }
         }
         else
-            _logger.LogError("Java input file {filePath} doesn't exist!", filePath);
-    }
-
-    private static void ShowHelp()
-    {
-        Console.WriteLine("Usage:");
-        Console.WriteLine("\tJavaToCSharpCli.exe -f [pathToJavaFile] [pathToCsOutputFile]");
-        Console.WriteLine("\tJavaToCSharpCli.exe -d [pathToJavaFolder] [pathToCsOutputFolder]");
+            _logger.LogError("Java input file {filePath} doesn't exist!", inputFile.FullName);
     }
 }


### PR DESCRIPTION
Resolves #58 except for package translations. Might add that in the future maybe with an i.e. `--replace-package=com.whatever.foo/Whatever.Foo` syntax? But that day is not today.