### PR TITLE
Fix/UI

### DIFF
--- a/JavaToCSharpGui/App.axaml
+++ b/JavaToCSharpGui/App.axaml
@@ -5,6 +5,6 @@
             RequestedThemeVariant="Default">
             <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
     <Application.Styles>
-        <FluentTheme />
+        <StyleInclude Source="avares://Semi.Avalonia/Themes/Index.axaml" />
     </Application.Styles>
 </Application>

--- a/JavaToCSharpGui/JavaToCSharpGui.csproj
+++ b/JavaToCSharpGui/JavaToCSharpGui.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.4" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.4" />
+    <PackageReference Include="Semi.Avalonia" Version="11.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\JavaToCSharp\JavaToCSharp.csproj" />

--- a/JavaToCSharpGui/ViewModels/MainWindowViewModel.cs
+++ b/JavaToCSharpGui/ViewModels/MainWindowViewModel.cs
@@ -303,8 +303,10 @@ public partial class MainWindowViewModel : ViewModelBase
     /// <param name="options">The user options used for the conversion.</param>
     private async Task FolderConvert(JavaConversionOptions? options)
     {
-        if (_javaFiles.Count == 0 || options == null)
+        if (_javaFiles.Count == 0 || options == null) {
+            ShowMessage("No Java files found in the specified folder!");
             return;
+        }
 
         var dir = new DirectoryInfo(OpenPath);
         var pDir = dir.Parent ?? throw new FileNotFoundException($"dir {OpenPath} parent");

--- a/JavaToCSharpGui/Views/MainWindow.axaml
+++ b/JavaToCSharpGui/Views/MainWindow.axaml
@@ -23,7 +23,29 @@
 							to C#. It does not resolve symbols or namespaces, so the resulting C# code likely will not compile without
 							modification. You must verify the results of the conversion manually.
 						</TextBlock>
-						<Button Grid.Column="1" Margin="0" VerticalAlignment="Top" HorizontalAlignment="Right" Content="fork me on GitHub!" Command="{CompiledBinding ForkMeOnGitHubCommand}" />
+						<StackPanel Grid.Column="1" Margin="0" VerticalAlignment="Top" HorizontalAlignment="Right" Orientation="Horizontal">
+							<Button Content="fork me on GitHub!" Command="{CompiledBinding ForkMeOnGitHubCommand}" />
+							<ToggleSwitch
+								Grid.Column="1"
+								Padding="4"
+								IsCheckedChanged="ToggleButton_OnIsCheckedChanged"
+								Theme="{DynamicResource ButtonToggleSwitch}">
+								<ToggleSwitch.OnContent>
+									<PathIcon
+										Width="16"
+										Height="16"
+										Data="M12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23ZM17 15C17.476 15 17.9408 14.9525 18.3901 14.862C17.296 17.3011 14.8464 19 12 19C8.13401 19 5 15.866 5 12C5 8.60996 7.40983 5.78277 10.6099 5.13803C10.218 6.01173 10 6.98041 10 8C10 11.866 13.134 15 17 15Z"
+										Foreground="{DynamicResource ButtonDefaultTertiaryForeground}" />
+								</ToggleSwitch.OnContent>
+								<ToggleSwitch.OffContent>
+									<PathIcon
+										Width="16"
+										Height="16"
+										Data="M3.55 19.09L4.96 20.5L6.76 18.71L5.34 17.29M12 6C8.69 6 6 8.69 6 12S8.69 18 12 18 18 15.31 18 12C18 8.68 15.31 6 12 6M20 13H23V11H20M17.24 18.71L19.04 20.5L20.45 19.09L18.66 17.29M20.45 5L19.04 3.6L17.24 5.39L18.66 6.81M13 1H11V4H13M6.76 5.39L4.96 3.6L3.55 5L5.34 6.81L6.76 5.39M1 13H4V11H1M13 20H11V23H13"
+										Foreground="{DynamicResource ButtonDefaultTertiaryForeground}" />
+								</ToggleSwitch.OffContent>
+							</ToggleSwitch>
+						</StackPanel>
 					</Grid>
 					<!-- GroupBox -->
 					<DockPanel Grid.Row="1">

--- a/JavaToCSharpGui/Views/MainWindow.axaml
+++ b/JavaToCSharpGui/Views/MainWindow.axaml
@@ -85,7 +85,7 @@
 			<Border Background="DarkGray" IsVisible="{CompiledBinding IsMessageShown}" Opacity="0.5" />
 			<WrapPanel Opacity="1" HorizontalAlignment="Center" VerticalAlignment="Center" IsVisible="{CompiledBinding IsMessageShown}">
 				<Border BorderBrush="Black" BorderThickness="2">					
-					<Grid MinWidth="100" RowDefinitions="Auto,*,Auto" Background="{StaticResource SystemControlBackgroundChromeMediumLowBrush}">
+					<Grid MinWidth="100" RowDefinitions="Auto,*,Auto" Background="{StaticResource WindowDefaultBackground}">
 						<Label Grid.Row="0" VerticalAlignment="Center" HorizontalAlignment="Center" FontWeight="Bold" Content="{CompiledBinding MessageTitle}" />
 						<TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Margin="10" TextWrapping="Wrap" Grid.Row="1" Text="{CompiledBinding Message}" />
 						<Button Content="OK" Margin="5" VerticalAlignment="Center" HorizontalAlignment="Center" Grid.Row="2" Command="{CompiledBinding ClearMessageCommand}" />

--- a/JavaToCSharpGui/Views/MainWindow.axaml
+++ b/JavaToCSharpGui/Views/MainWindow.axaml
@@ -14,75 +14,76 @@
 			to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
 		<vm:MainWindowViewModel/>
 	</Design.DataContext>
-	<ScrollViewer>
-		<Grid RowDefinitions="*,Auto" Margin="10">
-			<Grid Grid.Row="0" RowDefinitions="Auto,Auto,*">
-				<Grid Grid.Row="0" ColumnDefinitions="*,Auto">
-					<TextBlock Margin="10" TextWrapping="Wrap">
-						<Span FontWeight="Bold">NOTE:</Span> This tool does a <Span FontStyle="Italic">syntactic conversion only</Span> from Java
-						to C#. It does not resolve symbols or namespaces, so the resulting C# code likely will not compile without
-						modification. You must verify the results of the conversion manually.
-					</TextBlock>
-					<Button Grid.Column="1" Margin="0" VerticalAlignment="Top" HorizontalAlignment="Right" Content="fork me on GitHub!" Command="{CompiledBinding ForkMeOnGitHubCommand}" />
-				</Grid>
-				<!-- GroupBox -->
-				<DockPanel Grid.Row="1">
-					<Label DockPanel.Dock="Top" FontWeight="Bold" Content="Options" />
-					<Grid DockPanel.Dock="Bottom" ColumnDefinitions="*,*">
-						<StackPanel Orientation="Vertical">
-							<TextBlock Margin="5">Add Usings:</TextBlock>
-							<Grid ColumnDefinitions="*,Auto">
-								<TextBox Name="AddUsingInput" Margin="5,2,5,2" Text="{CompiledBinding AddUsingInput}" />
-								<Button Name="AddUsing" Grid.Column="1" Margin="5,2,5,2" Command="{CompiledBinding AddUsingCommand}">Add</Button>
-							</Grid>
-							<ListBox MinHeight="100"
-									 Margin="5"
-									 Name="Usings"
-									 ItemsSource="{CompiledBinding Usings}"
-									 SelectedItem="{CompiledBinding SelectedUsing}">
-							</ListBox>
-						</StackPanel>
-						<StackPanel Orientation="Vertical" Grid.Column="1">
-							<CheckBox Margin="5" Name="IncludeUsings" IsChecked="{CompiledBinding IncludeUsings}">Include Usings in Output</CheckBox>
-							<CheckBox Margin="5" Name="IncludeNamespace" IsChecked="{CompiledBinding IncludeNamespace}">Include Namespace in Output</CheckBox>
-							<CheckBox Margin="5" Name="IncludeComments" IsChecked="{CompiledBinding IncludeComments}">Include Comments in Output</CheckBox>
-							<CheckBox Margin="5" Name="UseDebugAssertForAsserts" IsChecked="{CompiledBinding UseDebugAssertForAsserts}">Use Debug.Assert() for asserts</CheckBox>
-							<CheckBox Margin="5" Name="UseUnrecognizedCodeToComment" IsChecked="{CompiledBinding UseUnrecognizedCodeToComment}">Use Unrecognized Code To Comment</CheckBox>
-							<CheckBox Margin="5" Name="UseFolderConvert" IsChecked="{CompiledBinding UseFolderConvert}">Use Folder Convert</CheckBox>
-							<CheckBox Margin="5" Name="ConvertSystemOutToConsole" IsChecked="{CompiledBinding ConvertSystemOutToConsole}">Convert System.out to Console</CheckBox>
-						</StackPanel>
+		<Grid>
+			<Grid Grid.RowDefinitions="*, Auto">
+				<Grid Grid.Row="0" RowDefinitions="Auto,Auto,*">
+					<Grid Grid.Row="0" ColumnDefinitions="*,Auto">
+						<TextBlock Margin="10" TextWrapping="Wrap">
+							<Span FontWeight="Bold">NOTE:</Span> This tool does a <Span FontStyle="Italic">syntactic conversion only</Span> from Java
+							to C#. It does not resolve symbols or namespaces, so the resulting C# code likely will not compile without
+							modification. You must verify the results of the conversion manually.
+						</TextBlock>
+						<Button Grid.Column="1" Margin="0" VerticalAlignment="Top" HorizontalAlignment="Right" Content="fork me on GitHub!" Command="{CompiledBinding ForkMeOnGitHubCommand}" />
 					</Grid>
-				</DockPanel>
-				<Grid Grid.Row="2" ColumnDefinitions="*,Auto,*">
-					<Grid RowDefinitions="Auto,Auto,*">
-						<TextBlock Margin="10">Java Source Code Input:</TextBlock>
-						<Grid Grid.Row="1" ColumnDefinitions="Auto,*,Auto">
-							<TextBlock Margin="10,5,10,5">File:</TextBlock>
-							<TextBox Name="OpenPath" Grid.Column="1" Margin="5" Text="{CompiledBinding OpenPath}" />
-							<Button Grid.Column="2" Margin="10,5,10,5" Command="{CompiledBinding OpenFileDialogCommand}" Name="OpenFileDialog">...</Button>
-						</Grid>
-						<TextBox Name="JavaText" Grid.Row="2" Margin="10" ScrollViewer.VerticalScrollBarVisibility="Visible" FontFamily="Consolas" AcceptsReturn="True"/>
-					</Grid>
-					<Button Grid.Row="2" Grid.Column="1" Name="Convert" IsEnabled="{CompiledBinding IsConvertEnabled}" Command="{CompiledBinding ConvertCommand}" Height="35" Margin="10">Convert!</Button>
-					<Grid Grid.Row="2" Grid.Column="2" RowDefinitions="Auto,*">
-						<Grid Grid.Row="0" ColumnDefinitions="Auto,*">
-							<TextBlock Margin="10">C# Output:</TextBlock>
-							<StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
-								<TextBlock Name="CopiedText" Margin="10" Text="{CompiledBinding CopiedText}"/>
-								<Button Name="CopyOutput" Margin="10" Command="{CompiledBinding CopyOutputCommand}">Copy to Clipboard</Button>
+					<!-- GroupBox -->
+					<DockPanel Grid.Row="1">
+						<Label DockPanel.Dock="Top" FontWeight="Bold" Content="Options" />
+						<Grid DockPanel.Dock="Bottom" ColumnDefinitions="*,*">
+							<StackPanel Orientation="Vertical">
+								<TextBlock Margin="5">Add Usings:</TextBlock>
+								<Grid ColumnDefinitions="*,Auto">
+									<TextBox Name="AddUsingInput" Margin="5,2,5,2" Text="{CompiledBinding AddUsingInput}" />
+									<Button Name="AddUsing" Grid.Column="1" Margin="5,2,5,2" Command="{CompiledBinding AddUsingCommand}">Add</Button>
+								</Grid>
+								<ListBox MinHeight="100"
+										Margin="5"
+										Name="Usings"
+										ItemsSource="{CompiledBinding Usings}"
+										SelectedItem="{CompiledBinding SelectedUsing}">
+								</ListBox>
+							</StackPanel>
+							<StackPanel Orientation="Vertical" Grid.Column="1">
+								<CheckBox Margin="5" Name="IncludeUsings" IsChecked="{CompiledBinding IncludeUsings}">Include Usings in Output</CheckBox>
+								<CheckBox Margin="5" Name="IncludeNamespace" IsChecked="{CompiledBinding IncludeNamespace}">Include Namespace in Output</CheckBox>
+								<CheckBox Margin="5" Name="IncludeComments" IsChecked="{CompiledBinding IncludeComments}">Include Comments in Output</CheckBox>
+								<CheckBox Margin="5" Name="UseDebugAssertForAsserts" IsChecked="{CompiledBinding UseDebugAssertForAsserts}">Use Debug.Assert() for asserts</CheckBox>
+								<CheckBox Margin="5" Name="UseUnrecognizedCodeToComment" IsChecked="{CompiledBinding UseUnrecognizedCodeToComment}">Use Unrecognized Code To Comment</CheckBox>
+								<CheckBox Margin="5" Name="UseFolderConvert" IsChecked="{CompiledBinding UseFolderConvert}">Use Folder Convert</CheckBox>
+								<CheckBox Margin="5" Name="ConvertSystemOutToConsole" IsChecked="{CompiledBinding ConvertSystemOutToConsole}">Convert System.out to Console</CheckBox>
 							</StackPanel>
 						</Grid>
-						<TextBox Name="CSharpText" Text="{CompiledBinding CSharpText}" Grid.Row="2" Margin="10" ScrollViewer.VerticalScrollBarVisibility="Visible" FontFamily="Consolas"></TextBox>
+					</DockPanel>
+					<Grid Grid.Row="2" ColumnDefinitions="*,Auto,*">
+						<Grid RowDefinitions="Auto,Auto,*">
+							<TextBlock Margin="10">Java Source Code Input:</TextBlock>
+							<Grid Grid.Row="1" ColumnDefinitions="Auto,*,Auto">
+								<TextBlock Margin="10,5,10,5">File:</TextBlock>
+								<TextBox Name="OpenPath" Grid.Column="1" Margin="5" Text="{CompiledBinding OpenPath}" />
+								<Button Grid.Column="2" Margin="10,5,10,5" Command="{CompiledBinding OpenFileDialogCommand}" Name="OpenFileDialog">...</Button>
+							</Grid>
+							<TextBox Name="JavaText" Grid.Row="2" Margin="10" ScrollViewer.VerticalScrollBarVisibility="Visible" FontFamily="Consolas" AcceptsReturn="True"/>
+						</Grid>
+						<Button Grid.Row="2" Grid.Column="1" Name="Convert" IsEnabled="{CompiledBinding IsConvertEnabled}" Command="{CompiledBinding ConvertCommand}" Height="35" Margin="10">Convert!</Button>
+						<Grid Grid.Row="2" Grid.Column="2" RowDefinitions="Auto,*">
+							<Grid Grid.Row="0" ColumnDefinitions="Auto,Auto">
+								<TextBlock Margin="10">C# Output:</TextBlock>
+								<StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+									<TextBlock Name="CopiedText" Margin="10" Text="{CompiledBinding CopiedText}"/>
+									<Button Name="CopyOutput" Margin="10" Command="{CompiledBinding CopyOutputCommand}">Copy to Clipboard</Button>
+								</StackPanel>
+							</Grid>
+							<TextBox Name="CSharpText" Text="{CompiledBinding CSharpText}" Grid.Row="2" Margin="10" ScrollViewer.VerticalScrollBarVisibility="Visible" FontFamily="Consolas"></TextBox>
+						</Grid>
 					</Grid>
 				</Grid>
+				<!-- StatusBar -->
+				<DockPanel Grid.Row="1">
+					<TextBlock Name="ConversionStateLabel" Text="{CompiledBinding ConversionStateLabel}" Margin="10" />
+				</DockPanel>
 			</Grid>
-			<!-- StatusBar -->
-			<DockPanel Grid.Row="1">
-				<TextBlock Name="ConversionStateLabel" Text="{CompiledBinding ConversionStateLabel}" Margin="10" />
-			</DockPanel>
 			<!-- MessageBox -->
-			<Border Grid.RowSpan="2" Background="DarkGray" IsVisible="{CompiledBinding IsMessageShown}" Opacity="0.5" />
-			<WrapPanel Grid.RowSpan="2" Opacity="1" HorizontalAlignment="Center" VerticalAlignment="Center" IsVisible="{CompiledBinding IsMessageShown}">
+			<Border Background="DarkGray" IsVisible="{CompiledBinding IsMessageShown}" Opacity="0.5" />
+			<WrapPanel Opacity="1" HorizontalAlignment="Center" VerticalAlignment="Center" IsVisible="{CompiledBinding IsMessageShown}">
 				<Border BorderBrush="Black" BorderThickness="2">					
 					<Grid MinWidth="100" RowDefinitions="Auto,*,Auto" Background="{StaticResource SystemControlBackgroundChromeMediumLowBrush}">
 						<Label Grid.Row="0" VerticalAlignment="Center" HorizontalAlignment="Center" FontWeight="Bold" Content="{CompiledBinding MessageTitle}" />
@@ -92,5 +93,4 @@
 				</Border>
 			</WrapPanel>
 		</Grid>
-	</ScrollViewer>
 </Window>

--- a/JavaToCSharpGui/Views/MainWindow.axaml
+++ b/JavaToCSharpGui/Views/MainWindow.axaml
@@ -81,7 +81,8 @@
 				<TextBlock Name="ConversionStateLabel" Text="{CompiledBinding ConversionStateLabel}" Margin="10" />
 			</DockPanel>
 			<!-- MessageBox -->
-			<WrapPanel Grid.RowSpan="2" HorizontalAlignment="Center" VerticalAlignment="Center" IsVisible="{CompiledBinding IsMessageShown}">
+			<Border Grid.RowSpan="2" Background="DarkGray" IsVisible="{CompiledBinding IsMessageShown}" Opacity="0.5" />
+			<WrapPanel Grid.RowSpan="2" Opacity="1" HorizontalAlignment="Center" VerticalAlignment="Center" IsVisible="{CompiledBinding IsMessageShown}">
 				<Border BorderBrush="Black" BorderThickness="2">					
 					<Grid MinWidth="100" RowDefinitions="Auto,*,Auto" Background="{StaticResource SystemControlBackgroundChromeMediumLowBrush}">
 						<Label Grid.Row="0" VerticalAlignment="Center" HorizontalAlignment="Center" FontWeight="Bold" Content="{CompiledBinding MessageTitle}" />

--- a/JavaToCSharpGui/Views/MainWindow.axaml
+++ b/JavaToCSharpGui/Views/MainWindow.axaml
@@ -61,7 +61,7 @@
 								<TextBox Name="OpenPath" Grid.Column="1" Margin="5" Text="{CompiledBinding OpenPath}" />
 								<Button Grid.Column="2" Margin="10,5,10,5" Command="{CompiledBinding OpenFileDialogCommand}" Name="OpenFileDialog">...</Button>
 							</Grid>
-							<TextBox Name="JavaText" Grid.Row="2" Margin="10" ScrollViewer.VerticalScrollBarVisibility="Visible" FontFamily="Consolas" AcceptsReturn="True"/>
+							<TextBox Name="JavaText" Text="{CompiledBinding JavaText}" Grid.Row="2" Margin="10" ScrollViewer.VerticalScrollBarVisibility="Visible" FontFamily="Consolas" AcceptsReturn="True"/>
 						</Grid>
 						<Button Grid.Row="2" Grid.Column="1" Name="Convert" IsEnabled="{CompiledBinding IsConvertEnabled}" Command="{CompiledBinding ConvertCommand}" Height="35" Margin="10">Convert!</Button>
 						<Grid Grid.Row="2" Grid.Column="2" RowDefinitions="Auto,*">

--- a/JavaToCSharpGui/Views/MainWindow.axaml.cs
+++ b/JavaToCSharpGui/Views/MainWindow.axaml.cs
@@ -1,4 +1,7 @@
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Styling;
 using JavaToCSharpGui.Infrastructure;
 using JavaToCSharpGui.ViewModels;
 
@@ -21,5 +24,15 @@ public partial class MainWindow : Window
         var vm = new MainWindowViewModel(storageProvider, dispatcher, clipboard);
         DataContext = vm;
         this.Usings.DoubleTapped += (_, _) => vm.RemoveSelectedUsingCommand.Execute(null);
+    }
+    
+    private void ToggleButton_OnIsCheckedChanged(object sender, RoutedEventArgs e)
+    {
+        var app = Application.Current;
+        if (app is not null)
+        {
+            var theme = app.ActualThemeVariant;
+            app.RequestedThemeVariant = theme == ThemeVariant.Dark ? ThemeVariant.Light : ThemeVariant.Dark;
+        }
     }
 }


### PR DESCRIPTION
Fixes #55 

Also fixes large code scrolling (the window was expanded and scrolled, instead of letting the textboxes use their own scrollviewer),

And the JavaText was not being shown,  this is fixed.

Along with other small UI layout thingies (for example: when an error is shown, the rest of the UI is covered with a semi-transparent border, so no interaction can occur).

This also uses Semi.Avalonia for nicer Dark and Light themes.

I could have used Material.Avalonia or Citrus, or Neumorphism, but this felt the nicest and the closest to the original light UI in light mode. Also Material.Avalonia made the buttons way too big.