### PR TITLE
long and double can not be volatile

### DIFF
--- a/JavaToCSharp/Declarations/FieldDeclarationVisitor.cs
+++ b/JavaToCSharp/Declarations/FieldDeclarationVisitor.cs
@@ -72,7 +72,7 @@ public class FieldDeclarationVisitor : BodyDeclarationVisitor<FieldDeclaration>
             fieldSyntax = fieldSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.StaticKeyword));
         if (mods.Contains(Modifier.Keyword.FINAL))
             fieldSyntax = fieldSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword));
-        if (mods.Contains(Modifier.Keyword.VOLATILE))
+        if (mods.Contains(Modifier.Keyword.VOLATILE) && !typeName.Equals("long") && !typeName.Equals("double")) // long and double can not be volatile in C#
             fieldSyntax = fieldSyntax.AddModifiers(SyntaxFactory.Token(SyntaxKind.VolatileKeyword));
 
         return fieldSyntax;


### PR DESCRIPTION
long and double can not be volatile, so this pr prevents the volatile keyword being applied to these types on field declaration. 