### PR TITLE
Add support for file-scoped namespaces, #113

### DIFF
--- a/JavaToCSharp/CommentsHelper.cs
+++ b/JavaToCSharp/CommentsHelper.cs
@@ -448,7 +448,7 @@ public static class CommentsHelper
                     }
 
                     node = statement.InsertTriviaBefore(leading[index],
-                        Enumerable.Repeat(SyntaxFactory.CarriageReturnLineFeed, 1));
+                        Enumerable.Repeat(Whitespace.NewLine, 1));
                 }
             }
 

--- a/JavaToCSharp/Declarations/ConstructorDeclarationVisitor.cs
+++ b/JavaToCSharp/Declarations/ConstructorDeclarationVisitor.cs
@@ -3,7 +3,6 @@ using com.github.javaparser.ast.body;
 using com.github.javaparser.ast.stmt;
 using com.github.javaparser.ast.type;
 using JavaToCSharp.Statements;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -24,8 +23,7 @@ public class ConstructorDeclarationVisitor : BodyDeclarationVisitor<ConstructorD
             return null;
         }
 
-        var ctorSyntax = SyntaxFactory.ConstructorDeclaration(identifier)
-                                      .WithLeadingTrivia(SyntaxFactory.CarriageReturnLineFeed);
+        var ctorSyntax = SyntaxFactory.ConstructorDeclaration(identifier).WithLeadingNewLines();
 
         var mods = ctorDecl.getModifiers().ToModifierKeywordSet();
 

--- a/JavaToCSharp/Extensions.cs
+++ b/JavaToCSharp/Extensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using java.util;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using JavaAst = com.github.javaparser.ast;
 
@@ -77,4 +78,12 @@ public static class Extensions
     public static ISet<JavaAst.Modifier.Keyword> ToModifierKeywordSet(this JavaAst.NodeList nodeList)
         => nodeList.ToList<JavaAst.Modifier>()?.Select(i => i.getKeyword()).ToHashSet()
            ?? new HashSet<JavaAst.Modifier.Keyword>();
+
+    public static TSyntax WithLeadingNewLines<TSyntax>(this TSyntax syntax, int count = 1)
+        where TSyntax : SyntaxNode
+        => syntax.WithLeadingTrivia(Enumerable.Repeat(Whitespace.NewLine, count));
+
+    public static TSyntax WithTrailingNewLines<TSyntax>(this TSyntax syntax, int count = 1)
+        where TSyntax : SyntaxNode
+        => syntax.WithTrailingTrivia(Enumerable.Repeat(Whitespace.NewLine, count));
 }

--- a/JavaToCSharp/JavaConversionOptions.cs
+++ b/JavaToCSharp/JavaConversionOptions.cs
@@ -31,6 +31,8 @@ public class JavaConversionOptions
 
     public bool IncludeComments { get; set; } = true;
 
+    public bool UseFileScopedNamespaces { get; set; }
+
     public ConversionState ConversionState { get; set; }
 
     public JavaConversionOptions AddPackageReplacement(string pattern, string replacement, RegexOptions options = RegexOptions.None)

--- a/JavaToCSharp/Whitespace.cs
+++ b/JavaToCSharp/Whitespace.cs
@@ -1,0 +1,11 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace JavaToCSharp;
+
+public static class Whitespace
+{
+    public static SyntaxTrivia NewLine => Environment.NewLine == "\r\n"
+        ? SyntaxFactory.CarriageReturnLineFeed
+        : SyntaxFactory.LineFeed;
+}

--- a/JavaToCSharpCli/Program.cs
+++ b/JavaToCSharpCli/Program.cs
@@ -48,6 +48,11 @@ public class Program
         description: "Convert System.out calls to Console",
         getDefaultValue: () => false);
 
+    private static readonly Option<bool> _fileScopedNamespacesOption = new(
+        name: "--file-scoped-namespaces",
+        description: "Use file-scoped namespaces in C# output",
+        getDefaultValue: () => false);
+
     private static readonly Option<bool> _clearDefaultUsingsOption = new(
         name: "--clear-usings",
         description: "Remove all default usings provided by this app",
@@ -84,6 +89,7 @@ public class Program
         rootCommand.AddGlobalOption(_startInterfaceNamesWithIOption);
         rootCommand.AddGlobalOption(_commentUnrecognizedCodeOption);
         rootCommand.AddGlobalOption(_systemOutToConsoleOption);
+        rootCommand.AddGlobalOption(_fileScopedNamespacesOption);
         rootCommand.AddGlobalOption(_clearDefaultUsingsOption);
         rootCommand.AddGlobalOption(_addUsingsOption);
 
@@ -131,7 +137,8 @@ public class Program
             ConvertSystemOutToConsole = context.ParseResult.GetValueForOption(_systemOutToConsoleOption),
             StartInterfaceNamesWithI = context.ParseResult.GetValueForOption(_startInterfaceNamesWithIOption),
             UseDebugAssertForAsserts = context.ParseResult.GetValueForOption(_useDebugAssertOption),
-            UseUnrecognizedCodeToComment = context.ParseResult.GetValueForOption(_commentUnrecognizedCodeOption)
+            UseUnrecognizedCodeToComment = context.ParseResult.GetValueForOption(_commentUnrecognizedCodeOption),
+            UseFileScopedNamespaces = context.ParseResult.GetValueForOption(_fileScopedNamespacesOption),
         };
 
         if (context.ParseResult.GetValueForOption(_clearDefaultUsingsOption))

--- a/JavaToCSharpGui/App.config
+++ b/JavaToCSharpGui/App.config
@@ -28,6 +28,9 @@
             <setting name="Usings" serializeAs="String">
                 <value>System;System.Collections.Generic;System.Collections.ObjectModel;System.Linq;System.Text</value>
             </setting>
+            <setting name="UseFileScopedNamespaces" serializeAs="String">
+                <value>False</value>
+            </setting>
         </JavaToCSharpGui.Properties.Settings>
     </userSettings>
 </configuration>

--- a/JavaToCSharpGui/CurrentOptions.cs
+++ b/JavaToCSharpGui/CurrentOptions.cs
@@ -13,6 +13,7 @@ public static class CurrentOptions
         Options.UseDebugAssertForAsserts = Settings.Default.UseDebugAssertPreference;
         Options.UseUnrecognizedCodeToComment = Settings.Default.UseUnrecognizedCodeToComment;
         Options.ConvertSystemOutToConsole = Settings.Default.ConvertSystemOutToConsole;
+        Options.UseFileScopedNamespaces = Settings.Default.UseFileScopedNamespaces;
 
         Options.SetUsings(Settings.Default.Usings.Split(';'));
     }
@@ -27,6 +28,7 @@ public static class CurrentOptions
         Settings.Default.UseDebugAssertPreference = Options.UseDebugAssertForAsserts;
         Settings.Default.UseUnrecognizedCodeToComment = Options.UseUnrecognizedCodeToComment;
         Settings.Default.ConvertSystemOutToConsole = Options.ConvertSystemOutToConsole;
+        Settings.Default.UseFileScopedNamespaces = Options.UseFileScopedNamespaces;
         Settings.Default.Usings = string.Join(";", Options.Usings);
 
         Settings.Default.Save();

--- a/JavaToCSharpGui/Properties/Settings.Designer.cs
+++ b/JavaToCSharpGui/Properties/Settings.Designer.cs
@@ -106,5 +106,17 @@ namespace JavaToCSharpGui.Properties {
                 this["Usings"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool UseFileScopedNamespaces {
+            get {
+                return ((bool)(this["UseFileScopedNamespaces"]));
+            }
+            set {
+                this["UseFileScopedNamespaces"] = value;
+            }
+        }
     }
 }

--- a/JavaToCSharpGui/Properties/Settings.settings
+++ b/JavaToCSharpGui/Properties/Settings.settings
@@ -23,5 +23,8 @@
     <Setting Name="Usings" Type="System.String" Scope="User">
       <Value Profile="(Default)">System;System.Collections.Generic;System.Collections.ObjectModel;System.Linq;System.Text</Value>
     </Setting>
+    <Setting Name="UseFileScopedNamespaces" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/JavaToCSharpGui/ViewModels/SettingsWindowViewModel.cs
+++ b/JavaToCSharpGui/ViewModels/SettingsWindowViewModel.cs
@@ -24,6 +24,8 @@ public partial class SettingsWindowViewModel : ViewModelBase
 
     [ObservableProperty] private bool _convertSystemOutToConsole = CurrentOptions.Options.ConvertSystemOutToConsole;
 
+    [ObservableProperty] private bool _useFileScopedNamespaces = CurrentOptions.Options.UseFileScopedNamespaces;
+
     public event EventHandler? CloseRequested;
 
     [RelayCommand]
@@ -51,6 +53,7 @@ public partial class SettingsWindowViewModel : ViewModelBase
         CurrentOptions.Options.UseDebugAssertForAsserts = UseDebugAssertForAsserts;
         CurrentOptions.Options.UseUnrecognizedCodeToComment = UnrecognizedCodeToComment;
         CurrentOptions.Options.ConvertSystemOutToConsole = ConvertSystemOutToConsole;
+        CurrentOptions.Options.UseFileScopedNamespaces = UseFileScopedNamespaces;
 
         CurrentOptions.Options.SetUsings(Usings);
 

--- a/JavaToCSharpGui/Views/SettingsWindow.axaml
+++ b/JavaToCSharpGui/Views/SettingsWindow.axaml
@@ -38,6 +38,10 @@
                               IsChecked="{CompiledBinding IncludeNamespace}">
                         Include namespace in output
                     </CheckBox>
+                    <CheckBox Margin="5" Name="UseFileScopedNamespaces"
+                              IsChecked="{CompiledBinding UseFileScopedNamespaces}">
+                        Use file-scoped namespaces
+                    </CheckBox>
                     <CheckBox Margin="5" Name="IncludeComments"
                               IsChecked="{CompiledBinding IncludeComments}">
                         Include comments in output


### PR DESCRIPTION
This change surfaced some annoying whitespace behavior with Roslyn's NormalizeWhitespace method, so this adds some leading/trailing newlines in places after NormalizeWhitespace is called to help prettify the output.