### PR TITLE
Convert array and string length into a property accessor

### DIFF
--- a/JavaToCSharp.Tests/ConvertExpressionTests.cs
+++ b/JavaToCSharp.Tests/ConvertExpressionTests.cs
@@ -1,0 +1,31 @@
+using com.github.javaparser;
+using com.github.javaparser.ast.expr;
+using JavaToCSharp.Expressions;
+
+namespace JavaToCSharp.Tests;
+
+public class ConvertExpressionTests
+{
+    [Theory]
+    [InlineData("lst.size()", "lst.Count")]
+    [InlineData("lst.get(i)", "lst[i]")]
+    [InlineData("lst.set(i, value)", "lst[i] = value")]
+    [InlineData("str.length()", "str.Length")]
+    [InlineData("arr.length", "arr.Length")]
+
+    //Conversion not done if param number does not match the required
+    [InlineData("obj.size(i)", "obj.Size(i)")]
+    [InlineData("obj.get()", "obj.Get()")]
+    [InlineData("obj.get(i, j)", "obj.Get(i,j)")]
+    [InlineData("obj.set(i)", "obj.Set(i)")]
+    [InlineData("obj.set(i, j ,k)", "obj.Set(i,j,k)")]
+    [InlineData("obj.length(i)", "obj.Length(i)")]
+    public void Convert_DesignatedMethods_Into_PropertyAccessors(string javaExpr, string expectedCSharpExpr)
+    {
+        ParseResult parseResult = new JavaParser().parseExpression(javaExpr);
+        Expression parsedExpr = parseResult.getResult().FromRequiredOptional<Expression>();
+        var expr = ExpressionVisitor.VisitExpression(new ConversionContext(new JavaConversionOptions()), parsedExpr);
+        Assert.Equal(expectedCSharpExpr, expr?.ToString());
+    }
+
+}

--- a/JavaToCSharp/Expressions/FieldAccessExpressionVisitor.cs
+++ b/JavaToCSharp/Expressions/FieldAccessExpressionVisitor.cs
@@ -32,6 +32,8 @@ public class FieldAccessExpressionVisitor : ExpressionVisitor<FieldAccessExpr>
         }
 
         var field = TypeHelper.EscapeIdentifier(fieldAccessExpr.getNameAsString());
+        // array length accessor should be capitalized
+        field = field == "length" ? "Length" : field;
 
         return SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, scopeSyntax, SyntaxFactory.IdentifierName(field));
     }

--- a/JavaToCSharp/TypeHelper.cs
+++ b/JavaToCSharp/TypeHelper.cs
@@ -211,9 +211,14 @@ public static class TypeHelper
 
             switch (methodName.getIdentifier())
             {
+                case "length" when args.size() == 0:
+                    var scopeSyntaxLength = ExpressionVisitor.VisitExpression(context, scope);
+                    transformedSyntax = ReplaceMethodByProperty(scopeSyntaxLength, "Length");
+                    return true;
+
                 case "size" when args.size() == 0:
                     var scopeSyntaxSize = ExpressionVisitor.VisitExpression(context, scope);
-                    transformedSyntax = ReplaceSizeByCount(scopeSyntaxSize);
+                    transformedSyntax = ReplaceMethodByProperty(scopeSyntaxSize, "Count");
                     return true;
 
                 case "get" when args.size() == 1:
@@ -244,7 +249,7 @@ public static class TypeHelper
         return false;
 
 
-        static MemberAccessExpressionSyntax? ReplaceSizeByCount(ExpressionSyntax? scopeSyntax)
+        static MemberAccessExpressionSyntax? ReplaceMethodByProperty(ExpressionSyntax? scopeSyntax, string identifier)
         {
             if (scopeSyntax is null)
             {
@@ -255,7 +260,7 @@ public static class TypeHelper
             return SyntaxFactory.MemberAccessExpression(
                 SyntaxKind.SimpleMemberAccessExpression,
                 scopeSyntax,
-                SyntaxFactory.IdentifierName(SyntaxFactory.Identifier("Count")));
+                SyntaxFactory.IdentifierName(SyntaxFactory.Identifier(identifier)));
         }
 
         static ExpressionSyntax ReplaceGetByIndexAccess(ConversionContext context, ExpressionSyntax scopeSyntax,


### PR DESCRIPTION
Fixes #119 
- Converts string length expressions `str.length()` into `str.Length`
- Converts array length expressions `arr.length` into `arr.Length`
- Adds tests for similar conversions already implemented (size, get, set)