### PR TITLE
Avoid repeated comments in subclasses and interface implementations

### DIFF
--- a/JavaToCSharp/CommentsHelper.cs
+++ b/JavaToCSharp/CommentsHelper.cs
@@ -232,6 +232,7 @@ public static class CommentsHelper
         return parentNode.getChildNodes()
             .OfType<JavaAst.Node>()
             .Where(sibling => sibling is not JavaComments.Comment)
+            .OrderBy(sibling => sibling.getEnd().FromOptional<JavaParser.Position>()) // fix #88
             .LastOrDefault(sibling =>
             {
                 var siblingEnd = sibling.getEnd().FromOptional<JavaParser.Position>();


### PR DESCRIPTION
Fixes #88, Fixes #131. See the discussion in this issue for the rationale of this fix.