### PR TITLE
Convert class bounded type parameters

### DIFF
--- a/JavaToCSharp.Tests/CommentTests.cs
+++ b/JavaToCSharp.Tests/CommentTests.cs
@@ -110,7 +110,7 @@ public class CommentTests(ITestOutputHelper testOutputHelper)
     [InlineData("Child extends Parent implements IParent", "Child : Parent, IParent")]
 
     [InlineData("Parent<T>", "Parent<T>")]
-    [InlineData("Child<T extends BoundType<T>>", "Child<T>")] // issue #125, should add: where T : BoundType<T>
+    [InlineData("Child<T extends BoundType<T>>", "Child<T>\n    where T : BoundType<T>")]
     [InlineData("Child extends Parent<BoundType>", "Child : Parent<BoundType>")]
     public void CommentsInsideClass_ShouldNotBeDuplicated_Fix_88(string javaClass, string csharpClass)
     {

--- a/JavaToCSharp/Declarations/ClassOrInterfaceDeclarationVisitor.cs
+++ b/JavaToCSharp/Declarations/ClassOrInterfaceDeclarationVisitor.cs
@@ -128,6 +128,7 @@ public class ClassOrInterfaceDeclarationVisitor : BodyDeclarationVisitor<ClassOr
         {
             classSyntax = classSyntax.AddTypeParameterListParameters(typeParams
                     .Select(i => SyntaxFactory.TypeParameter(i.getNameAsString())).ToArray());
+            classSyntax = classSyntax.AddConstraintClauses(TypeHelper.GetTypeParameterListConstraints(typeParams).ToArray());
         }
 
         var mods = classDecl.getModifiers().ToModifierKeywordSet();

--- a/JavaToCSharp/TypeHelper.cs
+++ b/JavaToCSharp/TypeHelper.cs
@@ -195,6 +195,31 @@ public static class TypeHelper
     }
 
     /// <summary>
+    /// Returns the list of C# type parameter constraints that must be added to a class syntax
+    /// to convert the java bounded type parameters of a class declaration.
+    /// e.g. to convert <![CDATA[ <T extends Clazz<T>> ]]> into <![CDATA[ <T> where T : Clazz<T> ]]>
+    /// </summary>
+    public static IEnumerable<TypeParameterConstraintClauseSyntax> GetTypeParameterListConstraints(List<TypeParameter> typeParams)
+    {
+        var typeParameterConstraints = new List<TypeParameterConstraintClauseSyntax>();
+        foreach (TypeParameter typeParam in typeParams)
+        {
+            if (typeParam.getTypeBound().size() > 0)
+            {
+                var typeConstraintsSyntax = new SeparatedSyntaxList<TypeParameterConstraintSyntax>();
+                foreach (ClassOrInterfaceType bound in typeParam.getTypeBound())
+                    typeConstraintsSyntax = typeConstraintsSyntax.Add(SyntaxFactory.TypeConstraint(SyntaxFactory.ParseTypeName(bound.asString())));
+
+                var typeIdentifier = SyntaxFactory.IdentifierName(typeParam.getName().asString());
+                var parameterConstraintClauseSyntax = SyntaxFactory.TypeParameterConstraintClause(typeIdentifier, typeConstraintsSyntax);
+
+                typeParameterConstraints.Add(parameterConstraintClauseSyntax);
+            }
+        }
+        return typeParameterConstraints;
+    }
+
+    /// <summary>
     /// Transforms method calls into property and indexer accesses where appropriate.
     /// </summary>
     /// <param name="context">The conversion context.</param>


### PR DESCRIPTION
This PR closes #125 by converting java bounded type parameters in class declarations into C# generic type constraints.

Draft will be ready after merge #126, rebase, and fix comment tests