### PR TITLE
List all keywords in TypeHelper.EscapeIdentifier

### DIFF
--- a/JavaToCSharp/TypeHelper.cs
+++ b/JavaToCSharp/TypeHelper.cs
@@ -118,12 +118,91 @@ public static class TypeHelper
     public static string EscapeIdentifier(string name)
     {
         // @ (C# Reference): https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/verbatim
-        return name switch {
-            "string" or "ref" or "object" or "int" or "short" or "float" or "long" or "double" or "decimal" or "in" or
-            "out" or "byte" or "class" or "delegate" or "params" or "is" or "as" or "base" or "namespace" or "event" or
-            "lock" or "operator" or "override" => "@" + name,
-            _ => name,
-        };
+        //C# Keywords: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/
+        switch (name)
+        {
+            case "abstract":
+            case "as":
+            case "base":
+            case "bool":
+            case "break":
+            case "byte":
+            case "case":
+            case "catch":
+            case "char":
+            case "checked":
+            case "class":
+            case "const":
+            case "continue":
+            case "decimal":
+            case "default":
+            case "delegate":
+            case "do":
+            case "double":
+            case "else":
+            case "enum":
+            case "event":
+            case "explicit":
+            case "extern":
+            case "false":
+            case "finally":
+            case "fixed":
+            case "float":
+            case "for":
+            case "foreach":
+            case "goto":
+            case "if":
+            case "implicit":
+            case "in":
+            case "int":
+            case "interface":
+            case "internal":
+            case "is":
+            case "lock":
+            case "long":
+            case "namespace":
+            case "new":
+            case "null":
+            case "object":
+            case "operator":
+            case "out":
+            case "override":
+            case "params":
+            case "private":
+            case "protected":
+            case "public":
+            case "readonly":
+            case "ref":
+            case "return":
+            case "sbyte":
+            case "sealed":
+            case "short":
+            case "sizeof":
+            case "stackalloc":
+            case "static":
+            case "string":
+            case "struct":
+            case "switch":
+            case "this":
+            case "throw":
+            case "true":
+            case "try":
+            case "typeof":
+            case "uint":
+            case "ulong":
+            case "unchecked":
+            case "unsafe":
+            case "ushort":
+            case "using":
+            case "virtual":
+            case "void":
+            case "volatile":
+            case "while":
+                return "@" + name;
+
+            default:
+                return name;
+        }
     }
 
     public static string ReplaceCommonMethodNames(string name)


### PR DESCRIPTION
#147 

While attempting to convert a Java file, JavaToCSharp crashed while parsing the following method parameter

```java
Structure struct
```
`struct` is a keyword in C#, but not in Java. As such, `JavaToCSharp.Declarations.MethodDeclarationVisitor.VisitInternal` was crashing here

```c#
var paramSyntax = SyntaxFactory.Parameter(
    attributeLists: [],
    modifiers: modifiers,
    type: TypeHelper.ConvertTypeSyntax(type, arrayLevel),
    identifier: SyntaxFactory.ParseToken(identifier),
    @default: null);
```
on the basis that the value passed to the `identifier` parameter was invalid. `SyntaxFactory.ParseToken` will produce a token of type `SyntaxKind.StructKeyword` in response to parsing `struct` rather than a simple identifier token. Earlier in `VisitInternal` the method `TypeHelper.EscapeIdentifier` is called, which prepends `@` to several types of keywords. Not all keywords are listed here however, so I have updated the list to specify all standard keywords as defined [here](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/). There are additional contextual keywords in C# but these should not apply for the purposes of escaping an identifier.