### PR TITLE
Fix event handlers added to JavaConversionOptions.WarningEncountered not being removed after each converted file

### DIFF
--- a/JavaToCSharpCli/Program.cs
+++ b/JavaToCSharpCli/Program.cs
@@ -273,7 +273,7 @@ public class Program
             {
                 string javaText = File.ReadAllText(inputFile.FullName);
 
-                options.WarningEncountered += (_, eventArgs) =>
+                void warningEncountered(object? sender, ConversionWarningEventArgs eventArgs)
                 {
                     if (outputFile != null)
                     {
@@ -283,10 +283,19 @@ public class Program
 
                     OutputFileOrPrint(outputFile != null ? Path.ChangeExtension(outputFile.FullName, ".warning") : null,
                         eventArgs.Message + Environment.NewLine);
-                };
+                }
 
-                string? parsed = JavaToCSharpConverter.ConvertText(javaText, options);
-                OutputFileOrPrint(outputFile?.FullName, parsed ?? string.Empty);
+                options.WarningEncountered += warningEncountered;
+
+                try
+                {
+                    string? parsed = JavaToCSharpConverter.ConvertText(javaText, options);
+                    OutputFileOrPrint(outputFile?.FullName, parsed ?? string.Empty);
+                }
+                finally
+                {
+                    options.WarningEncountered -= warningEncountered;
+                }
 
                 if (outputFile != null)
                 {


### PR DESCRIPTION
#146 

In JavaToCSharpCli, `Program.ConvertToCSharpFile` attaches an event handler to the `JavaConversionOptions.WarningEncountered` event handler. However, this event handler is not removed after the `ConvertToCSharpFile` method finishes converting the file. As a result, when processing multiple files, every file you process will be added to the existing list of delegates attached to this event handler, resulting in all files processed so far receiving warnings that do not apply to them. This change updates `ConvertToCSharpFile` to ensure the event handler is unregistered prior to the method's return