### PR TITLE
[fix] fix build failure from package vulnerability

### DIFF
--- a/JavaToCSharpGui/JavaToCSharpGui.csproj
+++ b/JavaToCSharpGui/JavaToCSharpGui.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Semi.Avalonia" Version="11.3.7.1" />
     <PackageReference Include="Semi.Avalonia.AvaloniaEdit" Version="11.2.0.1" />
     <PackageReference Include="TextMateSharp.Grammars" Version="1.0.70" />
+    <PackageReference Include="Tmds.DBus.Protocol" Version="0.94.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\JavaToCSharp\JavaToCSharp.csproj" />

--- a/JavaToCSharpGui/ViewModels/MainWindowViewModel.cs
+++ b/JavaToCSharpGui/ViewModels/MainWindowViewModel.cs
@@ -184,7 +184,7 @@ public partial class MainWindowViewModel : ViewModelBase
                     outDir.Create();
 
                 string outDirFullName = outDir.FullName;
-                int subStartIndex = dir.FullName.Length;
+                int subStartIndex = dir.FullName.Length - 1;
 
                 foreach (var jFile in FolderInputFiles.Where(static x => x.Directory is not null))
                 {


### PR DESCRIPTION
Package 'Tmds.DBus.Protocol' explicitly added as build fails from transient package usage. `Warning As Error: Package 'Tmds.DBus.Protocol' 0.21.2 has a known high severity vulnerability, [https://github.com/advisories/GHSA-xrw6-gwf8-vvr9](https://github.com/advisories/GHSA-xrw6-gwf8-vvr9)

File [JavaToCSharpGui\ViewModels\MainWindowViewModel.cs](https://github.com/paulirwin/JavaToCSharp/blob/master/JavaToCSharpGui/ViewModels/MainWindowViewModel.cs) 
Line187 has been changed from 
    `int subStartIndex = dir.FullName.Length;` to 
    `int subStartIndex = dir.FullName.Length - 1;`

- Fixes exception `'startIndex cannot be larger than length of string. (Parameter 'startIndex')'` thrown on line193, `string jOutPath = $"{outDirFullName}{jPath[subStartIndex..]}";` when sub directories are not present or .java files are directly under chosen directory
- Fixes improper directory duplicate creation when sub dirs are present.
Previous result takes `maindir/subdir_one/file_one.java` and creates 
`maindir/maindir_csharp_outputsubdir_one/file_one.java` & 
`maindir/maindir_csharp_output/subdir_one/file_one.java`
        	
current result takes 
`maindir/subdir_one/file_one.java` and cretes only
`maindir/maindir_csharp_output/subdir_one/file_one.java`